### PR TITLE
feat(shell): rebuild bg-grid with parallax, footer, and CSS utility extraction

### DIFF
--- a/src/components/bg-grid.tsx
+++ b/src/components/bg-grid.tsx
@@ -1,42 +1,99 @@
 import type { ReactNode } from 'react';
+import { useEffect, useRef } from 'react';
+
+const BLOB_TRANSITION = 'transform 0.9s cubic-bezier(0.22,1,0.36,1)';
 
 export function BGGrid({ children }: { children?: ReactNode }) {
+	const gridRef = useRef<HTMLDivElement>(null);
+	const dotsRef = useRef<HTMLDivElement>(null);
+	const blob1Ref = useRef<HTMLImageElement>(null);
+	const blob2Ref = useRef<HTMLImageElement>(null);
+
+	useEffect(() => {
+		if (blob2Ref.current) blob2Ref.current.style.transform = 'rotate(180deg)';
+
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce) return;
+
+		let mx = 0,
+			my = 0,
+			sy = 0,
+			raf: number | null = null;
+
+		const apply = () => {
+			raf = null;
+			if (gridRef.current)
+				gridRef.current.style.transform = `translate(${mx * 14}px, ${my * 14 - sy * 0.04}px)`;
+			if (dotsRef.current)
+				dotsRef.current.style.transform = `translate(${mx * 22}px, ${my * 22 - sy * 0.06}px)`;
+			if (blob1Ref.current)
+				blob1Ref.current.style.transform = `translate(${mx * 50}px, ${my * 40 + sy * 0.05}px)`;
+			if (blob2Ref.current)
+				blob2Ref.current.style.transform = `rotate(180deg) translate(${mx * 60}px, ${my * 48 - sy * 0.05}px)`;
+		};
+
+		const schedule = () => {
+			if (!raf) raf = requestAnimationFrame(apply);
+		};
+
+		const onMove = (e: MouseEvent) => {
+			mx = e.clientX / window.innerWidth - 0.5;
+			my = e.clientY / window.innerHeight - 0.5;
+			schedule();
+		};
+
+		const onScroll = () => {
+			sy = window.scrollY;
+			schedule();
+		};
+
+		window.addEventListener('mousemove', onMove);
+		window.addEventListener('scroll', onScroll, { passive: true });
+
+		return () => {
+			window.removeEventListener('mousemove', onMove);
+			window.removeEventListener('scroll', onScroll);
+			if (raf) cancelAnimationFrame(raf);
+		};
+	}, []);
+
 	return (
 		<>
 			{children}
-			<div
-				className="fixed inset-0 z-[-1] bg-transparent h-screen w-screen bg-linear-to-b from-muted to-background"
-				style={{
-					backgroundImage: 'linear-gradient(hsl(var(--muted)), hsl(var(--background)))'
-				}}
-			>
-				<div
-					className="w-full h-full"
-					style={{
-						backgroundSize: '50px 50px',
-						backgroundImage:
-							'linear-gradient(0deg, transparent 24%, hsl(var(--muted)/80%) 25%, hsl(var(--muted)/80%) 26%, transparent 27%, transparent 74%, hsl(var(--muted)/80%) 75%, hsl(var(--muted)/80%) 76%, transparent 77%, transparent), linear-gradient(90deg, transparent 24%, hsl(var(--muted)/80%) 25%, hsl(var(--muted)/80%) 26%, transparent 27%, transparent 74%, hsl(var(--muted)/80%) 75%, hsl(var(--muted)/80%) 76%, transparent 77%, transparent)'
-					}}
+
+			{/* Fixed background canvas */}
+			<div className="fixed inset-0 z-[-2] pointer-events-none overflow-hidden">
+				{/* Base gradient */}
+				<div className="absolute inset-[-10%] bg-grad-base" />
+
+				{/* Graph-paper grid — 1px lines, radial mask fades edges */}
+				<div ref={gridRef} className="absolute inset-[-120px] bg-grid-lines" />
+
+				{/* Orange dot intersections */}
+				<div ref={dotsRef} className="absolute inset-[-120px] bg-dots-layer opacity-[0.35]" />
+
+				{/* Colour blobs */}
+				<img
+					ref={blob1Ref}
+					className="absolute -left-10 top-32 w-[300px] h-[600px] opacity-50"
+					style={{ transition: BLOB_TRANSITION }}
+					src="/images/color_grad.webp"
+					alt=""
+					aria-hidden="true"
+				/>
+				<img
+					ref={blob2Ref}
+					className="absolute -right-10 -top-32 w-[200px] h-[400px] opacity-[0.15]"
+					style={{ transition: BLOB_TRANSITION }}
+					src="/images/color_grad.webp"
+					alt=""
+					aria-hidden="true"
 				/>
 			</div>
-			<img
-				className="fixed -left-10 top-32 scale-150 fade-in-35 duration-1000 opacity-55 z-[-1]"
-				alt="Decorative image element"
-				src={'/images/color_grad.webp'}
-				height={400}
-				width={200}
-				loading="eager"
-			/>
-			<img
-				className="fixed -right-10 -top-32 rotate-180 fade-in-35 duration-1000 opacity-15 z-[-1]"
-				alt="Decorative image element"
-				src={'/images/color_grad.webp'}
-				height={400}
-				width={200}
-				loading="eager"
-			/>
-			<div className="h-screen fixed border-l border-orange-600 opacity-30 left-[5px] md:left-[10%] top-0 bottom-0" />
-			<div className="h-screen fixed border-l border-orange-600 opacity-30 right-[5px] md:right-[10%] top-0 bottom-0" />
+
+			{/* Vertical orange sidelines */}
+			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px left-[max(14px,4vw)] bg-brand opacity-[0.22]" />
+			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px right-[max(14px,4vw)] bg-brand opacity-[0.22]" />
 		</>
 	);
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,29 @@
+import { data } from '@/data/main';
+
+const FOOTER_SOCIALS = ['GitHub', 'LinkedIn', 'Instagram'];
+
+export function Footer() {
+	const year = new Date().getFullYear();
+	const socials = data.contact.social.filter((s) => FOOTER_SOCIALS.includes(s.name));
+
+	return (
+		<footer className="container mx-auto mt-16 mb-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-muted-foreground">
+			<span>
+				© {year} {data.name} · {data.location}
+			</span>
+			<span className="flex gap-4">
+				{socials.map((social) => (
+					<a
+						key={social.name}
+						href={social.url}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="lowercase transition-colors hover:text-foreground"
+					>
+						{social.name}
+					</a>
+				))}
+			</span>
+		</footer>
+	);
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 import { BGGrid } from '@/components/bg-grid';
 import { CommandMenu } from '@/components/command-menu';
+import { Footer } from '@/components/footer';
 import { GoogleAnalytics } from '@/components/google-analytics';
 import { Navbar } from '@/components/navbar';
 import ProgressIndicator from '@/components/progress-indicator';
@@ -21,7 +22,7 @@ export interface LayoutProps {
 
 export default function Layout({ children, commandLinks = [] }: LayoutProps): ReactNode {
 	return (
-		<div className="max-w-full overflow-y-scroll overflow-x-hidden no-scrollbar antialiased mb-10 lg:mx-auto">
+		<div className="max-w-full overflow-y-scroll overflow-x-hidden no-scrollbar antialiased lg:mx-auto">
 			<GoogleAnalytics />
 			<Navbar />
 			<ProgressIndicator />
@@ -29,6 +30,7 @@ export default function Layout({ children, commandLinks = [] }: LayoutProps): Re
 				<BGGrid>{children}</BGGrid>
 				<CommandMenu links={commandLinks} />
 			</main>
+			<Footer />
 		</div>
 	);
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -152,6 +152,41 @@
 	}
 }
 
+@utility bg-grad-base {
+	background: linear-gradient(180deg, hsl(var(--muted)), hsl(var(--background)) 70%);
+}
+
+@utility bg-grid-lines {
+	background-size: 54px 54px;
+	background-image:
+		linear-gradient(
+			to right,
+			color-mix(in srgb, hsl(var(--border)) 55%, transparent) 1px,
+			transparent 1px
+		),
+		linear-gradient(
+			to bottom,
+			color-mix(in srgb, hsl(var(--border)) 55%, transparent) 1px,
+			transparent 1px
+		);
+	mask-image: radial-gradient(ellipse 90% 70% at 50% 35%, #000 55%, transparent 100%);
+	-webkit-mask-image: radial-gradient(ellipse 90% 70% at 50% 35%, #000 55%, transparent 100%);
+	will-change: transform;
+	transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@utility bg-dots-layer {
+	background-size: 54px 54px;
+	background-image: radial-gradient(
+		circle,
+		color-mix(in srgb, var(--color-orange-primary) 32%, transparent) 1.1px,
+		transparent 1.4px
+	);
+	background-position: 27px 27px;
+	will-change: transform;
+	transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 @utility scroll-fade-reveal {
 	opacity: 0;
 	transform: translateY(20px);


### PR DESCRIPTION
## Summary

- **BGGrid**: mouse + scroll parallax via `requestAnimationFrame` on grid, dots, and blobs at different depth multipliers; respects `prefers-reduced-motion`
- **CSS utilities**: extracted `bg-grad-base`, `bg-grid-lines`, `bg-dots-layer` into `globals.css` `@utility` blocks — removes all complex inline `style` props from the component
- **Sidelines**: fully Tailwind-classed (`left-[max(14px,4vw)]`, `bg-brand`, `opacity-[0.22]`)
- **Footer**: minimal global footer with copyright + GitHub/LinkedIn/Instagram social links; `font-mono`, `text-xs`, `border-t` separator
- **Layout**: imports and renders `Footer` below `<main>`

## Test plan

- [ ] Grid and dot layers shift subtly on mouse move (different parallax depths)
- [ ] Blobs drift on mouse move and counter-scroll
- [ ] No parallax movement when `prefers-reduced-motion: reduce` is set
- [ ] Footer renders at bottom of every page with correct year, name, location, and links
- [ ] Sidelines visible at correct inset on all viewport sizes
- [ ] Dark mode: gradient, grid, and dots adapt correctly via CSS variables