### PR TITLE
styles 🎨 : restyle navbar, theme toggle, and add JetBrains Mono

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,10 +1,7 @@
 import { data } from '@/data/main';
 
-const FOOTER_SOCIALS = ['GitHub', 'LinkedIn', 'Instagram'];
-
 export function Footer() {
 	const year = new Date().getFullYear();
-	const socials = data.contact.social.filter((s) => FOOTER_SOCIALS.includes(s.name));
 
 	return (
 		<footer className="container mx-auto mt-16 mb-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-muted-foreground">
@@ -12,7 +9,7 @@ export function Footer() {
 				© {year} {data.name} · {data.location}
 			</span>
 			<span className="flex gap-4">
-				{socials.map((social) => (
+				{data.contact.social.map((social) => (
 					<a
 						key={social.name}
 						href={social.url}

--- a/src/components/logo-ma.tsx
+++ b/src/components/logo-ma.tsx
@@ -4,6 +4,81 @@ import { cn } from '@/utils/utils';
 
 type LogoMAProps = SVGProps<SVGSVGElement>;
 
+export const LogoMark = ({ className, ...props }: LogoMAProps) => (
+	<svg
+		width="37"
+		height="18"
+		viewBox="0 3 37 18"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		role="img"
+		aria-label="Maria Adriana"
+		className={cn('w-auto', className)}
+		{...props}
+	>
+		<path
+			d="M8.97021 3.15039H16.8042C17.1323 3.1504 17.4299 3.31123 17.6089 3.5752V3.57617L22.9468 11.5566L22.9478 11.5596C23.1375 11.8333 23.1552 12.197 22.9907 12.5068L20.2017 17.7715H20.2007L20.1997 17.7734C19.8743 18.4153 18.9679 18.4634 18.5649 17.8604L18.564 17.8594L14.6899 12.0859C14.1608 11.2775 12.9514 11.3552 12.521 12.2031L8.44189 20.165C8.27773 20.4741 7.94907 20.6805 7.59326 20.6807H1.10205C0.403208 20.6807 -0.056433 19.9471 0.255371 19.3174L0.254395 19.3164L8.12256 3.67871L8.12549 3.67383C8.27157 3.35727 8.6116 3.15043 8.97021 3.15039Z"
+			fill="url(#lm_fill0)"
+			fillOpacity="0.2"
+			stroke="url(#lm_stroke0)"
+			strokeWidth="0.3"
+		/>
+		<path
+			d="M27.2495 4.93567C27.6094 4.25867 28.5934 4.2511 28.9478 4.92102V4.922L36.7476 19.4747C37.0707 20.1011 36.6148 20.8497 35.8804 20.8497H30.0444C29.326 20.8497 28.8718 20.1 29.1948 19.4913L29.1958 19.4894L29.1968 19.4884C29.1971 19.4877 29.1972 19.4866 29.1978 19.4855C29.1992 19.4828 29.2018 19.4791 29.2046 19.4738C29.2101 19.4631 29.2183 19.4466 29.229 19.4259C29.2504 19.3846 29.2819 19.3241 29.3218 19.2472C29.4019 19.0925 29.5163 18.8709 29.6538 18.6056C29.9287 18.075 30.2956 17.3672 30.6636 16.6583C31.0315 15.9495 31.401 15.2399 31.6802 14.7052C31.8197 14.4379 31.9369 14.2143 32.02 14.0568C32.0615 13.9782 32.0937 13.9158 32.1167 13.8732C32.1275 13.8532 32.1352 13.8369 32.1411 13.8263L32.147 13.8214L32.1577 13.7999L32.4995 13.1241L32.5005 13.1251C32.6486 12.8539 32.6268 12.5217 32.4585 12.2726C32.2961 12.0324 32.0279 11.8674 31.7144 11.8673H25.2231C24.5046 11.8673 24.0512 11.1166 24.3745 10.5079L24.3755 10.507L27.2505 4.93665L27.2495 4.93567Z"
+			fill="url(#lm_fill1)"
+			fillOpacity="0.2"
+			stroke="url(#lm_stroke1)"
+			strokeWidth="0.3"
+		/>
+		<defs>
+			<linearGradient
+				id="lm_fill0"
+				x1="11.63"
+				y1="3"
+				x2="11.63"
+				y2="20.83"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop stopColor="#929292" />
+				<stop offset="1" stopColor="#FBFBFB" />
+			</linearGradient>
+			<linearGradient
+				id="lm_stroke0"
+				x1="11.63"
+				y1="3"
+				x2="11.63"
+				y2="20.83"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop stopColor="var(--logo-stroke-start)" />
+				<stop offset="1" stopColor="var(--logo-stroke-end)" />
+			</linearGradient>
+			<linearGradient
+				id="lm_fill1"
+				x1="30.56"
+				y1="4.27"
+				x2="30.56"
+				y2="21"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop stopColor="#929292" />
+				<stop offset="1" stopColor="#FBFBFB" />
+			</linearGradient>
+			<linearGradient
+				id="lm_stroke1"
+				x1="30.56"
+				y1="4.27"
+				x2="30.56"
+				y2="21"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop stopColor="var(--logo-stroke-start)" />
+				<stop offset="1" stopColor="var(--logo-stroke-end)" />
+			</linearGradient>
+		</defs>
+	</svg>
+);
+
 export const LogoMA = ({
 	className,
 	role = 'img',

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,9 +1,16 @@
 import { Link, useRouterState } from '@tanstack/react-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
+import { LogoMark } from '@/components/logo-ma';
 import { NowPlaying } from '@/components/now-playing';
 import { ThemeToggle } from '@/components/theme-toggle';
+import { data } from '@/data/main';
 import { ROUTES } from '@/utils/routes';
+import { cn } from '@/utils/utils';
+
+const SM_BREAKPOINT = 640;
+const SCROLL_HIDE_THRESHOLD = 140;
+const SCROLL_BG_THRESHOLD = 20;
 
 const navItems = [
 	{ path: ROUTES.home, name: 'home' },
@@ -13,55 +20,203 @@ const navItems = [
 ];
 
 export function Navbar() {
-	const [show, setShow] = useState(true);
-	const [lastScrollY, setLastScrollY] = useState(0);
+	const [hidden, setHidden] = useState(false);
+	const [scrolled, setScrolled] = useState(false);
+	const [menuOpen, setMenuOpen] = useState(false);
+	const menuOpenRef = useRef(false);
 
 	const location = useRouterState({ select: (s) => s.location });
 
-	const controlNavbarVisibility = useCallback(() => {
-		if (window.scrollY > lastScrollY) {
-			setShow(false);
-		} else {
-			setShow(true);
-		}
-		setLastScrollY(window.scrollY);
-	}, [lastScrollY]);
+	useEffect(() => {
+		menuOpenRef.current = menuOpen;
+	}, [menuOpen]);
 
 	useEffect(() => {
-		window.addEventListener('scroll', controlNavbarVisibility);
-		return () => window.removeEventListener('scroll', controlNavbarVisibility);
-	}, [controlNavbarVisibility]);
+		let last = window.scrollY;
+		const onScroll = () => {
+			const y = window.scrollY;
+			setScrolled(y > SCROLL_BG_THRESHOLD);
+			setHidden(!menuOpenRef.current && y > SCROLL_HIDE_THRESHOLD && y > last);
+			last = y;
+		};
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => window.removeEventListener('scroll', onScroll);
+	}, []);
+
+	useEffect(() => {
+		const onResize = () => {
+			if (window.innerWidth >= SM_BREAKPOINT && menuOpenRef.current) setMenuOpen(false);
+		};
+		window.addEventListener('resize', onResize);
+		return () => window.removeEventListener('resize', onResize);
+	}, []);
+
+	useEffect(() => {
+		document.body.style.overflow = menuOpen ? 'hidden' : '';
+		return () => {
+			document.body.style.overflow = '';
+		};
+	}, [menuOpen]);
+
+	const isActive = (path: string) =>
+		path === ROUTES.home ? location.pathname === ROUTES.home : location.pathname.startsWith(path);
 
 	return (
-		<nav
-			className={`${
-				show ? 'opacity-100 top-0' : 'opacity-0 top-[-400px]'
-			} ease-in-out transition-all duration-1000 w-full fixed z-10 pt-3 md:pt-10 border-b border-b-[#F3C6A7] dark:border-b-[#4D2512] from-white-600/10 dark:from-teal-200/10 via-white dark:via-black to-slate-600/10 dark:to-slate-600/10 backdrop-blur-xs`}
-		>
-			<div className="flex flex-row justify-between flex-wrap w-full container md:px-0 max-w-2xl mx-auto mb-2 md:mb-4 print:space-y-6 gap-2 md:gap-5 place-items-center">
-				<div className="flex flex-row pr-1 gap-2">
-					<ThemeToggle />
-					<div className="flex flex-row pr-1 gap-2">
-						{navItems.map(({ path, name }) => {
-							return (
+		<>
+			<nav
+				className={cn(
+					'fixed top-0 left-0 w-full z-50 pt-3',
+					'border-b border-[var(--nav-border)]',
+					'nav-transition',
+					scrolled ? 'nav-bg-scrolled' : 'nav-bg',
+					hidden ? '-translate-y-[130%] opacity-0' : 'translate-y-0 opacity-100'
+				)}
+			>
+				<div className="max-w-[760px] mx-auto px-6 pb-[9px] flex items-center justify-between gap-[10px]">
+					<div className="flex items-center gap-1 min-w-0">
+						<Link
+							to={ROUTES.home}
+							className="flex items-center mr-2 no-underline text-foreground"
+							aria-label="Home"
+							onClick={() => setMenuOpen(false)}
+						>
+							<LogoMark className="logo-fade h-[19px]" />
+						</Link>
+
+						<div className="hidden sm:flex gap-px">
+							{navItems.map(({ path, name }) => (
 								<Link
 									key={path}
 									to={path}
-									className={`transition-all hover:text-neutral-2 flex align-middle relative py-1 px-2 ${
-										location.pathname.split('/')[1] === path.replace('/', '') &&
-										'dark:text-orange-200 text-orange-700'
-									}`}
+									className={cn(
+										'font-mono text-[13px] tracking-[0.01em] no-underline',
+										'opacity-70 px-[9px] py-1 rounded-[6px] cursor-pointer',
+										'transition-[opacity,background,color] duration-[250ms] ease-linear',
+										'hover:opacity-100 hover:bg-[color-mix(in_srgb,hsl(var(--accent))_55%,transparent)]',
+										isActive(path)
+											? 'opacity-100 text-[var(--color-orange-primary)]'
+											: 'text-foreground'
+									)}
 								>
 									{name}
 								</Link>
-							);
-						})}
+							))}
+						</div>
+					</div>
+
+					<div className="flex items-center gap-[7px] shrink-0">
+						<div className="hidden sm:block">
+							<NowPlaying />
+						</div>
+						<ThemeToggle />
+
+						<button
+							className="sm:hidden bg-card-ghost relative w-8 h-8 rounded-[8px] border border-border cursor-pointer shrink-0 transition-[background] duration-[250ms] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							onClick={() => setMenuOpen((m) => !m)}
+							aria-label="Toggle menu"
+							aria-expanded={menuOpen}
+						>
+							<span
+								className={cn(
+									'absolute left-1/2 top-1/2 w-[15px] h-[1.5px] bg-foreground rounded-[2px]',
+									'transition-[translate,rotate] duration-[320ms] ease-out',
+									menuOpen
+										? 'translate-x-[-50%] translate-y-[-50%] rotate-45'
+										: 'translate-x-[-50%] translate-y-[calc(-50%_-_4px)]'
+								)}
+							/>
+							<span
+								className={cn(
+									'absolute left-1/2 top-1/2 w-[15px] h-[1.5px] bg-foreground rounded-[2px]',
+									'transition-[translate,rotate] duration-[320ms] ease-out',
+									menuOpen
+										? 'translate-x-[-50%] translate-y-[-50%] -rotate-45'
+										: 'translate-x-[-50%] translate-y-[calc(-50%_+_4px)]'
+								)}
+							/>
+						</button>
 					</div>
 				</div>
-				<div className="flex basis-full justify-start max-w-80 h-full sm:basis-auto sm:justify-end">
-					<NowPlaying />
+			</nav>
+
+			<div
+				aria-hidden={!menuOpen}
+				className={cn(
+					'fixed inset-0 z-[48] flex flex-col justify-center',
+					'px-[max(28px,7vw)] pt-24 pb-10 bg-background',
+					'transition-[clip-path] duration-500 [transition-timing-function:cubic-bezier(0.25,1,0.5,1)]',
+					menuOpen
+						? 'nav-overlay-open pointer-events-auto'
+						: 'nav-overlay-closed pointer-events-none'
+				)}
+			>
+				<div
+					className="absolute inset-0 overlay-grid opacity-[0.04] pointer-events-none"
+					aria-hidden="true"
+				/>
+
+				<nav className="relative flex flex-col">
+					{navItems.map(({ path, name }, i) => (
+						<Link
+							key={path}
+							to={path}
+							className={cn(
+								'flex items-baseline gap-4 border-b border-border no-underline',
+								'font-clash font-medium tracking-[-0.03em]',
+								'text-[clamp(40px,13vw,68px)] leading-[1.04] py-[10px]',
+								'[transition:opacity_300ms_ease-out,translate_300ms_ease-out]',
+								isActive(path) ? 'text-[var(--color-orange-primary)]' : 'text-foreground'
+							)}
+							style={{
+								opacity: menuOpen ? 1 : 0,
+								translate: menuOpen ? 'none' : '0 26px',
+								transitionDelay: menuOpen ? `${0.12 + i * 0.06}s` : '0s'
+							}}
+							onClick={() => setMenuOpen(false)}
+						>
+							<span className="font-mono text-[13px] font-semibold text-[var(--color-orange-primary)] translate-y-[-0.4em]">
+								{String(i + 1).padStart(2, '0')}
+							</span>
+							<span className="flex-1">{name}</span>
+							<span
+								className={cn(
+									'font-mono text-[22px]',
+									'[transition:opacity_300ms_ease-out,translate_300ms_ease-out,color_300ms_ease-out]',
+									isActive(path) ? 'text-[var(--color-orange-primary)]' : 'text-muted-foreground'
+								)}
+								style={{
+									opacity: isActive(path) ? 1 : 0,
+									translate: isActive(path) ? 'none' : '-8px 4px'
+								}}
+							>
+								↗
+							</span>
+						</Link>
+					))}
+				</nav>
+
+				<div
+					className={cn(
+						'relative flex items-center flex-wrap gap-4 mt-auto pt-8',
+						'transition-opacity duration-500',
+						menuOpen ? 'opacity-100' : 'opacity-0'
+					)}
+				>
+					<span className="flex gap-4 font-mono text-[12px]">
+						{data.contact.social.map((s) => (
+							<a
+								key={s.name}
+								href={s.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="lowercase text-foreground no-underline opacity-70 transition-[opacity,color] duration-200 hover:opacity-100 hover:text-[var(--color-orange-primary)]"
+							>
+								{s.name}
+							</a>
+						))}
+					</span>
 				</div>
 			</div>
-		</nav>
+		</>
 	);
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -13,13 +13,18 @@ export function ThemeToggle() {
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
-				<Button variant="outline" size="theme-toggle" className="bg-card text-card-foreground">
-					<SunIcon className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-					<MoonIcon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+				<Button
+					variant="outline"
+					size="theme-toggle"
+					className="relative bg-card-ghost rounded-full border-border shrink-0 [transition:background_400ms_ease,rotate_150ms_ease] hover:rotate-[18deg] data-[state=open]:rotate-0 focus-visible:ring-offset-0"
+					aria-label="Toggle theme"
+				>
+					<SunIcon className="h-[14px] w-[14px] rotate-0 scale-100 transition-all duration-300 dark:-rotate-90 dark:scale-0" />
+					<MoonIcon className="absolute h-[14px] w-[14px] rotate-90 scale-0 transition-all duration-300 dark:rotate-0 dark:scale-100" />
 					<span className="sr-only">Toggle theme</span>
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start">
+			<DropdownMenuContent align="end">
 				<DropdownMenuItem onClick={() => applyTheme('light')}>Light</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => applyTheme('dark')}>Dark</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => applyTheme('system')}>System</DropdownMenuItem>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
 				lg: 'h-11 rounded-md px-8',
 				contact: 'h-8 rounded-md px-2',
 				icon: 'h-10 w-10',
-				'theme-toggle': 'h-8 w-8'
+				'theme-toggle': 'h-[30px] w-[30px]'
 			}
 		},
 		defaultVariants: {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -14,7 +14,15 @@ export const Route = createRootRoute({
 			{ charSet: 'utf-8' as const },
 			{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
 		],
-		links: [{ rel: 'icon', type: 'image/x-icon', href: '/images/favicon.ico' }]
+		links: [
+			{ rel: 'icon', type: 'image/x-icon', href: '/images/favicon.ico' },
+			{ rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+			{ rel: 'preconnect', href: 'https://fonts.gstatic.com', crossOrigin: 'anonymous' },
+			{
+				rel: 'stylesheet',
+				href: 'https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap'
+			}
+		]
 	}),
 	loader: async () => {
 		const commandLinks = await getCommandLinksFn();

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -191,6 +191,56 @@
 	}
 }
 
+@utility bg-card-ghost {
+	background: color-mix(in srgb, hsl(var(--card)) 60%, transparent);
+}
+
+@utility nav-transition {
+	transition:
+		translate 1000ms ease-in-out,
+		opacity 1000ms ease-in-out,
+		background 400ms ease;
+}
+
+@utility nav-bg {
+	background: linear-gradient(
+		to right,
+		transparent,
+		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 12%,
+		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 88%,
+		transparent
+	);
+	backdrop-filter: blur(8px) saturate(1.1);
+	-webkit-backdrop-filter: blur(8px) saturate(1.1);
+}
+
+@utility nav-bg-scrolled {
+	background: linear-gradient(
+		to right,
+		color-mix(in srgb, hsl(var(--background)) 72%, transparent),
+		color-mix(in srgb, hsl(var(--background)) 96%, transparent) 12%,
+		color-mix(in srgb, hsl(var(--background)) 96%, transparent) 88%,
+		color-mix(in srgb, hsl(var(--background)) 72%, transparent)
+	);
+	backdrop-filter: blur(12px) saturate(1.2);
+	-webkit-backdrop-filter: blur(12px) saturate(1.2);
+}
+
+@utility nav-overlay-open {
+	clip-path: circle(150% at calc(100% - 42px) 34px);
+}
+
+@utility nav-overlay-closed {
+	clip-path: circle(0% at calc(100% - 42px) 34px);
+}
+
+@utility overlay-grid {
+	background-size: 54px 54px;
+	background-image:
+		linear-gradient(to right, hsl(var(--foreground)) 1px, transparent 1px),
+		linear-gradient(to bottom, hsl(var(--foreground)) 1px, transparent 1px);
+}
+
 @utility bg-grad-base {
 	background: linear-gradient(180deg, hsl(var(--muted)), hsl(var(--background)) 70%);
 }


### PR DESCRIPTION
## What

Restyled the navbar and theme toggle to match the v2 reference design.

- `LogoMark` icon-only export added to `logo-ma.tsx` for use in the navbar brand slot
- Navbar rebuilt: scroll-hide/reveal animation, frosted glass background on scroll, mobile fullscreen overlay with clip-path reveal, staggered link entrance, burger animation
- Theme toggle restyled to a circular 30px pill with sun/moon icon swap and hover rotation
- JetBrains Mono loaded via Google Fonts preconnect in `__root.tsx`
- All nav-specific CSS extracted to `@utility` classes (`nav-transition`, `nav-bg`, `nav-bg-scrolled`, `nav-overlay-open/closed`, `overlay-grid`, `bg-card-ghost`)
- Mobile overlay closes on viewport resize past `sm` breakpoint
- All socials displayed unfiltered in both navbar overlay and footer

## Linear

Closes PER-11

## Checklist

- [x] `pnpm validate` passes
- [x] Tested locally