### PR TITLE
feat ✨ : add app initial loader and route-transition page loader

### DIFF
--- a/src/components/app-loader.tsx
+++ b/src/components/app-loader.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+
+export function AppLoaderShell() {
+	return (
+		<div id="app-loader" aria-hidden="true">
+			<div id="app-loader-bar" />
+		</div>
+	);
+}
+
+export function AppLoaderDismiss() {
+	useEffect(() => {
+		const el = document.getElementById('app-loader');
+		if (!el) return;
+
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+			el.remove();
+			return;
+		}
+
+		el.style.opacity = '0';
+		const timer = setTimeout(() => el.remove(), 550);
+		return () => clearTimeout(timer);
+	}, []);
+
+	return null;
+}

--- a/src/components/page-loader.tsx
+++ b/src/components/page-loader.tsx
@@ -1,0 +1,15 @@
+export function PageLoader() {
+	return (
+		<div
+			role="status"
+			aria-label="Loading page"
+			className="flex items-center justify-center min-h-[50vh]"
+		>
+			<span className="sr-only">Loading…</span>
+			<span
+				className="w-5 h-5 rounded-full border-2 border-t-transparent animate-spin motion-reduce:animate-none"
+				style={{ borderColor: 'var(--color-orange-primary)', borderTopColor: 'transparent' }}
+			/>
+		</div>
+	);
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createRouter } from '@tanstack/react-router';
 
+import { PageLoader } from '@/components/page-loader';
 import { routeTree } from '@/routeTree.gen';
 
 function createAppRouter() {
@@ -10,7 +11,7 @@ function createAppRouter() {
 		routeTree,
 		defaultPreload: 'intent',
 		defaultPreloadDelay: 0,
-		defaultPendingComponent: () => <></>,
+		defaultPendingComponent: PageLoader,
 		defaultPendingMs: 150,
 		defaultPendingMinMs: 250,
 		notFoundMode: 'root',

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,7 @@
 import { createRootRoute, HeadContent, Link, Scripts } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 
+import { AppLoaderDismiss, AppLoaderShell } from '@/components/app-loader';
 import Layout from '@/components/layout';
 import { Button } from '@/components/ui/button';
 import { Toaster } from '@/components/ui/sonner';
@@ -45,9 +46,11 @@ function RootDocument({ children }: { children: ReactNode }) {
 				<HeadContent />
 			</head>
 			<body>
+				<AppLoaderShell />
 				<Layout commandLinks={commandLinks}>{children}</Layout>
 				<WebMcpRegistration />
 				<Toaster />
+				<AppLoaderDismiss />
 				<Scripts />
 			</body>
 		</html>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -466,6 +466,44 @@
 }
 
 @layer components {
+	#app-loader {
+		position: fixed;
+		inset: 0;
+		z-index: 9999;
+		background: hsl(48, 100%, 97%);
+		transition: opacity 0.5s ease;
+	}
+
+	html.dark #app-loader {
+		background: hsl(0, 3%, 6%);
+	}
+
+	#app-loader-bar {
+		position: absolute;
+		top: 0;
+		left: -40%;
+		width: 40%;
+		height: 2px;
+		background: linear-gradient(90deg, transparent, #f15a24, #f18b3e, transparent);
+		animation: al-scan 1.2s ease-in-out infinite;
+	}
+
+	@keyframes al-scan {
+		to {
+			left: 100%;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		#app-loader-bar {
+			animation: none;
+			left: 0;
+			width: 100%;
+			background: #f15a24;
+			opacity: 0.3;
+		}
+	}
+
 	.progress {
 		height: 0.18rem;
 	}


### PR DESCRIPTION
## What

- Adds a full-screen branded app loader that covers the page on initial load and fades out once React hydrates (`AppLoaderShell` + `AppLoaderDismiss`)
- Loader styles live in `globals.css`
- Respects `prefers-reduced-motion` — skips fade, shows a static bar instead of animated scan
- Replaces the empty `defaultPendingComponent` in the router with an accessible branded `PageLoader` spinner for route transitions (only appears after 150ms pending, stops animating under reduced motion)

## Linear

Closes PER-14

## Checklist

- [x] `pnpm validate` passes
- [x] Tested locally