### PR TITLE
feat ✨ : restyle contact form and align global max-width (PER-45)

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
 	const year = new Date().getFullYear();
 
 	return (
-		<footer className="container mx-auto mt-16 mb-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-muted-foreground">
+		<footer className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-16 mb-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-muted-foreground">
 			<span>
 				© {year} {data.name} · {data.location}
 			</span>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -72,7 +72,7 @@ export function Navbar() {
 					hidden ? '-translate-y-[130%] opacity-0' : 'translate-y-0 opacity-100'
 				)}
 			>
-				<div className="max-w-[760px] mx-auto px-6 pb-[9px] flex items-center justify-between gap-[10px]">
+				<div className="max-w-[1100px] mx-auto px-6 pb-[9px] flex items-center justify-between gap-[10px]">
 					<div className="flex items-center gap-1 min-w-0">
 						<Link
 							to={ROUTES.home}

--- a/src/components/pages/contact/form.tsx
+++ b/src/components/pages/contact/form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { LuArrowUpRight } from 'react-icons/lu';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
@@ -7,18 +8,23 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import type { ContactResponse } from '@/server/routes/api/types/contact';
-import { REGEX_EMAIL } from '@/utils/regex';
+import { cn } from '@/utils/utils';
+
+const contactSchema = z.object({
+	name: z.string().min(1, 'Required.'),
+	email: z.email('Invalid email.'),
+	subject: z.string().min(1, 'Required.'),
+	message: z.string().min(1, 'Required.'),
+	website: z.string().trim().max(0, 'Invalid submission.')
+});
+type ContactFormValues = z.infer<typeof contactSchema>;
+
+const LABEL_CLS =
+	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)]';
+const FIELD_CLS =
+	'h-auto rounded-[12px] bg-background border-border px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms]';
 
 export const ContactForm = () => {
-	const contactSchema = z.object({
-		name: z.string().min(1, 'Required field.'),
-		email: z.email('Invalid e-mail.'),
-		subject: z.string().min(1, 'Required field.'),
-		message: z.string().min(1, 'Required field.'),
-		website: z.string().trim().max(0, 'Invalid submission.')
-	});
-	type ContactFormValues = z.infer<typeof contactSchema>;
-
 	const {
 		register,
 		handleSubmit,
@@ -27,44 +33,29 @@ export const ContactForm = () => {
 	} = useForm<ContactFormValues>({
 		resolver: zodResolver(contactSchema),
 		mode: 'onChange',
-		defaultValues: {
-			website: ''
-		}
+		defaultValues: { website: '' }
 	});
 
 	const onSubmit: SubmitHandler<ContactFormValues> = async (data) => {
-		if (!isValid) {
-			toast.error('Cannot submit. Form has errors.');
-			return;
-		}
-
 		const request = await fetch('/api/send', {
 			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json'
-			},
+			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(data)
 		});
 
 		const response: ContactResponse = await request.json();
 
 		if (!request.ok) {
-			toast.error(response.message || 'Failed to submit. Please try again.');
-			return;
-		}
-
-		if (!response.message) {
-			console.log(response);
-			toast.error('Unexpected response from server.');
+			toast.error(response.message || 'Failed to send. Please try again.');
 			return;
 		}
 
 		reset();
-		toast.success('Submitted with success. Will get in touch soon.');
+		toast.success("Sent! I'll get back to you soon.");
 	};
 
 	return (
-		<form className="flex flex-col w-full gap-4" onSubmit={handleSubmit(onSubmit)}>
+		<form className="flex flex-col gap-[22px]" onSubmit={handleSubmit(onSubmit)}>
 			<div
 				className="absolute left-[-9999px] top-auto h-px w-px overflow-hidden opacity-0"
 				aria-hidden="true"
@@ -79,62 +70,93 @@ export const ContactForm = () => {
 				/>
 			</div>
 
-			<div className="flex flex-col gap-2 w-full animate-fade-in-left delay-[150ms]">
-				<Label htmlFor="name-input">Name</Label>
-				<Input
-					id="name-input"
-					className="form-input"
-					type="text"
-					{...register('name', { required: 'Required field.' })}
-				/>
-				{errors.name && <span>{errors.name.message}</span>}
+			<div className="grid grid-cols-1 min-[520px]:grid-cols-2 gap-[22px]">
+				<div className="group flex flex-col">
+					<Label htmlFor="name-input" className={LABEL_CLS}>
+						Your name
+					</Label>
+					<Input
+						id="name-input"
+						type="text"
+						placeholder="Jane Doe"
+						className={FIELD_CLS}
+						{...register('name')}
+					/>
+					{errors.name && (
+						<span className="mt-[6px] font-mono text-[11px] text-destructive">
+							{errors.name.message}
+						</span>
+					)}
+				</div>
+
+				<div className="group flex flex-col">
+					<Label htmlFor="email-input" className={LABEL_CLS}>
+						Email
+					</Label>
+					<Input
+						id="email-input"
+						type="email"
+						placeholder="jane@email.com"
+						className={FIELD_CLS}
+						{...register('email')}
+					/>
+					{errors.email && (
+						<span className="mt-[6px] font-mono text-[11px] text-destructive">
+							{errors.email.message}
+						</span>
+					)}
+				</div>
 			</div>
 
-			<div className="flex flex-col gap-2 w-full animate-fade-in-left delay-[250ms]">
-				<Label htmlFor="email-input">E-mail</Label>
-				<Input
-					id="email-input"
-					className="form-input"
-					type="email"
-					{...register('email', {
-						required: 'Required field.',
-						pattern: {
-							value: REGEX_EMAIL,
-							message: 'Invalid e-mail.'
-						}
-					})}
-				/>
-				{errors.email && <span>{errors.email.message}</span>}
-			</div>
-
-			<div className="flex flex-col gap-2 w-full animate-fade-in-left delay-[350ms]">
-				<Label htmlFor="subject-input">Subject</Label>
+			<div className="group flex flex-col">
+				<Label htmlFor="subject-input" className={LABEL_CLS}>
+					Subject
+				</Label>
 				<Input
 					id="subject-input"
-					className="form-input"
 					type="text"
-					{...register('subject', { required: 'Required field.' })}
+					placeholder="What's this about?"
+					className={FIELD_CLS}
+					{...register('subject')}
 				/>
-				{errors.subject && <span>{errors.subject.message}</span>}
+				{errors.subject && (
+					<span className="mt-[6px] font-mono text-[11px] text-destructive">
+						{errors.subject.message}
+					</span>
+				)}
 			</div>
 
-			<div className="flex flex-col gap-2 w-full animate-fade-in-left delay-[450ms]">
-				<Label htmlFor="message-input">Message</Label>
+			<div className="group flex flex-col">
+				<Label htmlFor="message-input" className={LABEL_CLS}>
+					Message
+				</Label>
 				<Textarea
 					id="message-input"
-					className="form-input"
-					{...register('message', { required: 'Required field.' })}
+					placeholder="Tell me a little about it…"
+					className={cn(FIELD_CLS, 'min-h-[132px] resize-vertical leading-[1.6]')}
+					{...register('message')}
 				/>
-				{errors.message && <span>{errors.message.message}</span>}
+				{errors.message && (
+					<span className="mt-[6px] font-mono text-[11px] text-destructive">
+						{errors.message.message}
+					</span>
+				)}
 			</div>
 
-			<Button
-				className="animate-fade-in-left delay-[550ms]"
-				type="submit"
-				disabled={!isValid || isSubmitting}
-			>
-				Submit
-			</Button>
+			<div className="flex flex-col gap-[10px]">
+				<Button
+					type="submit"
+					variant="ghost"
+					disabled={!isValid || isSubmitting}
+					className="self-start rounded-full px-6 h-auto py-[14px] gap-[11px] bg-[var(--color-orange-primary)] text-white hover:bg-[var(--color-orange-primary)] hover:text-white hover:-translate-y-[3px] hover:shadow-[0_18px_34px_-12px_color-mix(in_srgb,var(--color-orange-primary)_60%,transparent)] font-mono text-[14px] disabled:opacity-40 transition-[translate,box-shadow] duration-[400ms] [transition-timing-function:var(--ease-out)]"
+				>
+					{isSubmitting ? 'Sending…' : 'Send message'}
+					<LuArrowUpRight className="w-4 h-4" aria-hidden="true" />
+				</Button>
+				<p className="m-0 font-mono text-[11px] text-muted-foreground">
+					Or just email me directly — whatever's easier.
+				</p>
+			</div>
 		</form>
 	);
 };

--- a/src/components/pages/contact/form.tsx
+++ b/src/components/pages/contact/form.tsx
@@ -8,7 +8,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import type { ContactResponse } from '@/server/routes/api/types/contact';
-import { cn } from '@/utils/utils';
 
 const contactSchema = z.object({
 	name: z.string().min(1, 'Required.'),
@@ -18,11 +17,6 @@ const contactSchema = z.object({
 	website: z.string().trim().max(0, 'Invalid submission.')
 });
 type ContactFormValues = z.infer<typeof contactSchema>;
-
-const LABEL_CLS =
-	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)]';
-const FIELD_CLS =
-	'h-auto rounded-[12px] bg-background border-border px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms]';
 
 export const ContactForm = () => {
 	const {
@@ -72,75 +66,47 @@ export const ContactForm = () => {
 
 			<div className="grid grid-cols-1 min-[520px]:grid-cols-2 gap-[22px]">
 				<div className="group flex flex-col">
-					<Label htmlFor="name-input" className={LABEL_CLS}>
-						Your name
-					</Label>
+					<Label htmlFor="name-input">Your name</Label>
 					<Input
 						id="name-input"
 						type="text"
 						placeholder="Jane Doe"
-						className={FIELD_CLS}
+						error={errors.name?.message}
 						{...register('name')}
 					/>
-					{errors.name && (
-						<span className="mt-[6px] font-mono text-[11px] text-destructive">
-							{errors.name.message}
-						</span>
-					)}
 				</div>
 
 				<div className="group flex flex-col">
-					<Label htmlFor="email-input" className={LABEL_CLS}>
-						Email
-					</Label>
+					<Label htmlFor="email-input">Email</Label>
 					<Input
 						id="email-input"
 						type="email"
 						placeholder="jane@email.com"
-						className={FIELD_CLS}
+						error={errors.email?.message}
 						{...register('email')}
 					/>
-					{errors.email && (
-						<span className="mt-[6px] font-mono text-[11px] text-destructive">
-							{errors.email.message}
-						</span>
-					)}
 				</div>
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="subject-input" className={LABEL_CLS}>
-					Subject
-				</Label>
+				<Label htmlFor="subject-input">Subject</Label>
 				<Input
 					id="subject-input"
 					type="text"
 					placeholder="What's this about?"
-					className={FIELD_CLS}
+					error={errors.subject?.message}
 					{...register('subject')}
 				/>
-				{errors.subject && (
-					<span className="mt-[6px] font-mono text-[11px] text-destructive">
-						{errors.subject.message}
-					</span>
-				)}
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="message-input" className={LABEL_CLS}>
-					Message
-				</Label>
+				<Label htmlFor="message-input">Message</Label>
 				<Textarea
 					id="message-input"
 					placeholder="Tell me a little about it…"
-					className={cn(FIELD_CLS, 'min-h-[132px] resize-vertical leading-[1.6]')}
+					error={errors.message?.message}
 					{...register('message')}
 				/>
-				{errors.message && (
-					<span className="mt-[6px] font-mono text-[11px] text-destructive">
-						{errors.message.message}
-					</span>
-				)}
 			</div>
 
 			<div className="flex flex-col gap-[10px]">

--- a/src/components/pages/home/layout.tsx
+++ b/src/components/pages/home/layout.tsx
@@ -10,7 +10,7 @@ import type { Project } from '@/data/projects';
 export const HomeLayout = ({ projects }: { projects: Project[] }) => {
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<section className="mx-auto w-full max-w-2xl space-y-64 md:space-y-48 print:space-y-6 animate-fade-in-left delay-500">
+			<section className="mx-auto w-full max-w-[1100px] space-y-64 md:space-y-48 print:space-y-6 animate-fade-in-left delay-500">
 				<ScrollFadeReveal onLoadVisibility>
 					<SectionHero />
 				</ScrollFadeReveal>

--- a/src/components/pages/home/section-hero.tsx
+++ b/src/components/pages/home/section-hero.tsx
@@ -56,8 +56,8 @@ export const SectionHero = () => {
 				</span>
 			</h1>
 
-			<div className="flex items-start justify-between gap-7 max-sm:gap-[22px] mt-[34px] flex-wrap">
-				<div style={{ flex: '1 1 300px' }}>
+			<div className="flex items-start justify-start gap-7 max-sm:gap-[22px] mt-[34px] flex-wrap">
+				<div style={{ flex: '0 1 420px' }}>
 					<div className="font-clash text-[19px] font-normal h-[26px] overflow-hidden flex items-center">
 						<AnimatedMottos
 							data={[...data.mottos]}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,20 +2,25 @@ import * as React from 'react';
 
 import { cn } from '@/utils/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+	error?: string;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-	({ className, type, ...props }, ref) => {
+	({ className, type, error, ...props }, ref) => {
 		return (
-			<input
-				type={type}
-				className={cn(
-					'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-					className
-				)}
-				ref={ref}
-				{...props}
-			/>
+			<>
+				<input
+					type={type}
+					className={cn(
+						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] text-foreground placeholder:text-muted-foreground/80 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] disabled:cursor-not-allowed disabled:opacity-50',
+						className
+					)}
+					ref={ref}
+					{...props}
+				/>
+				{error && <span className="mt-[6px] font-mono text-[11px] text-destructive">{error}</span>}
+			</>
 		);
 	}
 );

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/utils/utils';
 
 const labelVariants = cva(
-	'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)] peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 );
 
 const Label = React.forwardRef<

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,19 +2,24 @@ import * as React from 'react';
 
 import { cn } from '@/utils/utils';
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+	error?: string;
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-	({ className, ...props }, ref) => {
+	({ className, error, ...props }, ref) => {
 		return (
-			<textarea
-				className={cn(
-					'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-					className
-				)}
-				ref={ref}
-				{...props}
-			/>
+			<>
+				<textarea
+					className={cn(
+						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.6] text-foreground placeholder:text-muted-foreground/80 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] min-h-[132px] resize-vertical disabled:cursor-not-allowed disabled:opacity-50',
+						className
+					)}
+					ref={ref}
+					{...props}
+				/>
+				{error && <span className="mt-[6px] font-mono text-[11px] text-destructive">{error}</span>}
+			</>
 		);
 	}
 );

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -34,7 +34,7 @@ function ContactRoute(): JSX.Element {
 
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<div className="mx-auto w-full max-w-2xl animate-fade-in-left delay-500">
+			<div className="mx-auto w-full max-w-[1100px] animate-fade-in-left delay-500">
 				<header className="pt-8 pb-[clamp(56px,9vw,104px)]">
 					<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,112px)] leading-[0.92] tracking-[-0.038em]">
 						<StaggerText
@@ -52,7 +52,7 @@ function ContactRoute(): JSX.Element {
 								letterDelay={0.028}
 							/>
 						</em>
-						{'\u00A0'}
+						<br />
 						<StaggerText
 							text="together"
 							revealed={revealed}
@@ -67,7 +67,7 @@ function ContactRoute(): JSX.Element {
 					</p>
 				</header>
 
-				<div className="grid grid-cols-1 sm:grid-cols-[0.82fr_1.18fr] gap-[clamp(32px,6vw,88px)] items-start">
+				<div className="grid grid-cols-1 min-[880px]:grid-cols-[0.82fr_1.18fr] gap-[clamp(32px,6vw,88px)] items-start">
 					<div className="flex flex-col gap-8">
 						<div>
 							<p className="m-0 mb-3 font-mono text-[11px] tracking-[0.12em] uppercase text-muted-foreground">
@@ -150,7 +150,7 @@ function ContactRoute(): JSX.Element {
 							</span>
 						</div>
 						<SectionHeading title="A few quick answers" />
-						<div className="grid grid-cols-1 sm:grid-cols-3 gap-[18px]">
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-[18px] mb-10 lg:mb-20">
 							{data.contact.faq.map((item) => (
 								<div key={item.q} className="entry-card border border-border rounded-[14px] p-6">
 									<h4 className="m-0 mb-[10px] font-clash font-medium text-[18px] tracking-[-0.01em]">

--- a/src/utils/regex.ts
+++ b/src/utils/regex.ts
@@ -1,1 +1,0 @@
-export const REGEX_EMAIL = /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/;


### PR DESCRIPTION
## What
Restyle the contact form to match the reference design — 2-column name/email row, full-border rounded fields, orange focus ring, label focus-within colour, pill submit button with arrow, and hint text. Also aligns all page widths (navbar, homepage, contact, footer) to a uniform `max-w-[1100px]`.

## Linear
Closes PER-45

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally