### PR TITLE
fix: harden contact API — HTML escaping, field limits, rate-limit memory leak (PER-46)

### DIFF
--- a/server/routes/api/send/post.ts
+++ b/server/routes/api/send/post.ts
@@ -1,7 +1,11 @@
 import nodemailer from 'nodemailer';
 import { z } from 'zod';
 import { getEnv } from '@/lib/env';
-import type { ContactInfo, ContactResponse } from '@/server/routes/api/types/contact';
+import {
+	CONTACT_FIELD_MAX,
+	type ContactInfo,
+	type ContactResponse
+} from '@/server/routes/api/types/contact';
 import { normalizeString } from '@/utils/string';
 
 import { buildContactEmailHtml } from './template';
@@ -10,10 +14,10 @@ const RATE_LIMIT_WINDOW_MS = 3 * 60 * 1000;
 const recentByEmail = new Map<string, number>();
 
 const contactInfoSchema = z.object({
-	email: z.string().trim().min(1),
-	message: z.string().trim().min(1),
-	name: z.string().trim().min(1),
-	subject: z.string().trim().min(1)
+	email: z.email().max(CONTACT_FIELD_MAX.email),
+	message: z.string().trim().min(1).max(CONTACT_FIELD_MAX.message),
+	name: z.string().trim().min(1).max(CONTACT_FIELD_MAX.name),
+	subject: z.string().trim().min(1).max(CONTACT_FIELD_MAX.subject)
 });
 
 const honeypotSchema = z.object({
@@ -81,13 +85,17 @@ export async function handleSendPost(request: Request): Promise<Response> {
 	}
 
 	recentByEmail.set(normalizedEmail, now);
+	setTimeout(() => {
+		if (recentByEmail.get(normalizedEmail) === now) recentByEmail.delete(normalizedEmail);
+	}, RATE_LIMIT_WINDOW_MS);
 
 	try {
 		const env = getEnv();
-		const info = await createTransporter().sendMail({
+		const safeSubject = contactInfo.subject.replace(/[\r\n]/g, ' ');
+		await createTransporter().sendMail({
 			from: env.SMTP_FROM,
 			to: env.SMTP_TO,
-			subject: `Contact request: ${contactInfo.subject}`,
+			subject: `Contact request: ${safeSubject}`,
 			html: buildContactEmailHtml({
 				name: contactInfo.name,
 				email: normalizedEmail,
@@ -95,7 +103,9 @@ export async function handleSendPost(request: Request): Promise<Response> {
 			})
 		});
 
-		return Response.json({ message: info.response } satisfies ContactResponse, { status: 200 });
+		return Response.json({ message: 'Message sent successfully.' } satisfies ContactResponse, {
+			status: 200
+		});
 	} catch (error) {
 		recentByEmail.delete(normalizedEmail);
 		console.error('Error sending email:', error);

--- a/server/routes/api/send/template.ts
+++ b/server/routes/api/send/template.ts
@@ -4,11 +4,24 @@ type ContactEmailTemplateParams = {
 	name: string;
 };
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}
+
 export function buildContactEmailHtml({
 	email,
 	message,
 	name
 }: ContactEmailTemplateParams): string {
+	const safeName = escapeHtml(name);
+	const safeEmail = escapeHtml(email);
+	const safeMessage = escapeHtml(message).replace(/\n/g, '<br>');
+
 	return `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
           <html lang="en">
             <head>
@@ -17,12 +30,12 @@ export function buildContactEmailHtml({
             </head>
             <body>
               <div class="container" style="margin-left: 20px;margin-right: 20px;">
-                <h3>You've got a new mail from ${name}, their email is:
-                  <br>${email}
+                <h3>You've got a new mail from ${safeName}, their email is:
+                  <br>${safeEmail}
                 </h3>
                 <div style="font-size: 16px;">
                   <p>Message:</p>
-                  <p>${message}</p>
+                  <p>${safeMessage}</p>
                   <br>
                 </div>
                 <p class="footer" style="font-size: 16px;padding-bottom: 20px;border-bottom: 1px solid #D1D5DB;">

--- a/server/routes/api/types/contact.ts
+++ b/server/routes/api/types/contact.ts
@@ -1,3 +1,10 @@
+export const CONTACT_FIELD_MAX = {
+	name: 100,
+	email: 254,
+	subject: 200,
+	message: 5000
+} as const;
+
 export type ContactInfo = {
 	name: string;
 	email: string;

--- a/src/components/pages/contact/form.tsx
+++ b/src/components/pages/contact/form.tsx
@@ -7,13 +7,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import type { ContactResponse } from '@/server/routes/api/types/contact';
+import { CONTACT_FIELD_MAX, type ContactResponse } from '@/server/routes/api/types/contact';
 
 const contactSchema = z.object({
-	name: z.string().min(1, 'Required.'),
-	email: z.email('Invalid email.'),
-	subject: z.string().min(1, 'Required.'),
-	message: z.string().min(1, 'Required.'),
+	name: z.string().min(1, 'Required.').max(CONTACT_FIELD_MAX.name, 'Too long.'),
+	email: z.email('Invalid email.').max(CONTACT_FIELD_MAX.email, 'Too long.'),
+	subject: z.string().min(1, 'Required.').max(CONTACT_FIELD_MAX.subject, 'Too long.'),
+	message: z.string().min(1, 'Required.').max(CONTACT_FIELD_MAX.message, 'Too long.'),
 	website: z.string().trim().max(0, 'Invalid submission.')
 });
 type ContactFormValues = z.infer<typeof contactSchema>;

--- a/src/components/pages/contact/form.tsx
+++ b/src/components/pages/contact/form.tsx
@@ -8,7 +8,6 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import type { ContactResponse } from '@/server/routes/api/types/contact';
-import { cn } from '@/utils/utils';
 
 const contactSchema = z.object({
 	name: z.string().min(1, 'Required.'),
@@ -18,11 +17,6 @@ const contactSchema = z.object({
 	website: z.string().trim().max(0, 'Invalid submission.')
 });
 type ContactFormValues = z.infer<typeof contactSchema>;
-
-const LABEL_CLS =
-	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)]';
-const FIELD_CLS =
-	'h-auto rounded-[12px] bg-background border-border px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms]';
 
 export const ContactForm = () => {
 	const {
@@ -72,75 +66,47 @@ export const ContactForm = () => {
 
 			<div className="grid grid-cols-1 min-[520px]:grid-cols-2 gap-[22px]">
 				<div className="group flex flex-col">
-					<Label htmlFor="name-input" className={LABEL_CLS}>
-						Your name
-					</Label>
+					<Label htmlFor="name-input">Your name</Label>
 					<Input
 						id="name-input"
 						type="text"
 						placeholder="Jane Doe"
-						className={FIELD_CLS}
+						error={errors.name?.message}
 						{...register('name')}
 					/>
-					{errors.name && (
-						<span className="mt-[6px] font-mono text-[11px] text-destructive">
-							{errors.name.message}
-						</span>
-					)}
 				</div>
 
 				<div className="group flex flex-col">
-					<Label htmlFor="email-input" className={LABEL_CLS}>
-						Email
-					</Label>
+					<Label htmlFor="email-input">Email</Label>
 					<Input
 						id="email-input"
 						type="email"
 						placeholder="jane@email.com"
-						className={FIELD_CLS}
+						error={errors.email?.message}
 						{...register('email')}
 					/>
-					{errors.email && (
-						<span className="mt-[6px] font-mono text-[11px] text-destructive">
-							{errors.email.message}
-						</span>
-					)}
 				</div>
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="subject-input" className={LABEL_CLS}>
-					Subject
-				</Label>
+				<Label htmlFor="subject-input">Subject</Label>
 				<Input
 					id="subject-input"
 					type="text"
 					placeholder="What's this about?"
-					className={FIELD_CLS}
+					error={errors.subject?.message}
 					{...register('subject')}
 				/>
-				{errors.subject && (
-					<span className="mt-[6px] font-mono text-[11px] text-destructive">
-						{errors.subject.message}
-					</span>
-				)}
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="message-input" className={LABEL_CLS}>
-					Message
-				</Label>
+				<Label htmlFor="message-input">Message</Label>
 				<Textarea
 					id="message-input"
 					placeholder="Tell me a little about it…"
-					className={cn(FIELD_CLS, 'min-h-[132px] resize-vertical leading-[1.6]')}
+					error={errors.message?.message}
 					{...register('message')}
 				/>
-				{errors.message && (
-					<span className="mt-[6px] font-mono text-[11px] text-destructive">
-						{errors.message.message}
-					</span>
-				)}
 			</div>
 
 			<div className="flex flex-col gap-[10px]">

--- a/src/components/pages/contact/form.tsx
+++ b/src/components/pages/contact/form.tsx
@@ -8,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import type { ContactResponse } from '@/server/routes/api/types/contact';
+import { cn } from '@/utils/utils';
 
 const contactSchema = z.object({
 	name: z.string().min(1, 'Required.'),
@@ -17,6 +18,11 @@ const contactSchema = z.object({
 	website: z.string().trim().max(0, 'Invalid submission.')
 });
 type ContactFormValues = z.infer<typeof contactSchema>;
+
+const LABEL_CLS =
+	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)]';
+const FIELD_CLS =
+	'h-auto rounded-[12px] bg-background border-border px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] placeholder:text-muted-foreground/80 focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms]';
 
 export const ContactForm = () => {
 	const {
@@ -66,47 +72,75 @@ export const ContactForm = () => {
 
 			<div className="grid grid-cols-1 min-[520px]:grid-cols-2 gap-[22px]">
 				<div className="group flex flex-col">
-					<Label htmlFor="name-input">Your name</Label>
+					<Label htmlFor="name-input" className={LABEL_CLS}>
+						Your name
+					</Label>
 					<Input
 						id="name-input"
 						type="text"
 						placeholder="Jane Doe"
-						error={errors.name?.message}
+						className={FIELD_CLS}
 						{...register('name')}
 					/>
+					{errors.name && (
+						<span className="mt-[6px] font-mono text-[11px] text-destructive">
+							{errors.name.message}
+						</span>
+					)}
 				</div>
 
 				<div className="group flex flex-col">
-					<Label htmlFor="email-input">Email</Label>
+					<Label htmlFor="email-input" className={LABEL_CLS}>
+						Email
+					</Label>
 					<Input
 						id="email-input"
 						type="email"
 						placeholder="jane@email.com"
-						error={errors.email?.message}
+						className={FIELD_CLS}
 						{...register('email')}
 					/>
+					{errors.email && (
+						<span className="mt-[6px] font-mono text-[11px] text-destructive">
+							{errors.email.message}
+						</span>
+					)}
 				</div>
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="subject-input">Subject</Label>
+				<Label htmlFor="subject-input" className={LABEL_CLS}>
+					Subject
+				</Label>
 				<Input
 					id="subject-input"
 					type="text"
 					placeholder="What's this about?"
-					error={errors.subject?.message}
+					className={FIELD_CLS}
 					{...register('subject')}
 				/>
+				{errors.subject && (
+					<span className="mt-[6px] font-mono text-[11px] text-destructive">
+						{errors.subject.message}
+					</span>
+				)}
 			</div>
 
 			<div className="group flex flex-col">
-				<Label htmlFor="message-input">Message</Label>
+				<Label htmlFor="message-input" className={LABEL_CLS}>
+					Message
+				</Label>
 				<Textarea
 					id="message-input"
 					placeholder="Tell me a little about it…"
-					error={errors.message?.message}
+					className={cn(FIELD_CLS, 'min-h-[132px] resize-vertical leading-[1.6]')}
 					{...register('message')}
 				/>
+				{errors.message && (
+					<span className="mt-[6px] font-mono text-[11px] text-destructive">
+						{errors.message.message}
+					</span>
+				)}
 			</div>
 
 			<div className="flex flex-col gap-[10px]">


### PR DESCRIPTION
## What

- HTML-escape all user-provided values (`name`, `email`, `message`) in the email template to prevent content injection
- Strip `\r\n` from the subject field to prevent email header injection
- Add email format validation + max-length limits server-side (`email: 254`, `name: 100`, `subject: 200`, `message: 5000`)
- Extract limits to shared `CONTACT_FIELD_MAX` constant in `contact.ts`, consumed by both server schema and client Zod schema
- Fix unbounded `recentByEmail` Map memory leak — entries now auto-delete after `RATE_LIMIT_WINDOW_MS` via `setTimeout` with a timestamp guard
- Return stable `'Message sent successfully.'` instead of leaking raw SMTP `info.response`

## Linear
Closes PER-46

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally