### PR TITLE
feat ✨ : restyle command menu and Spotify now-playing widget

### DIFF
--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from '@tanstack/react-router';
+import { useLenis } from 'lenis/react';
 import { useEffect, useState } from 'react';
+import { LuExternalLink, LuFileText, LuLayers, LuNavigation, LuSearch } from 'react-icons/lu';
 
 import {
 	CommandDialog,
@@ -10,17 +12,53 @@ import {
 	CommandList,
 	CommandSeparator
 } from '@/components/ui/command';
+import { cn } from '@/utils/utils';
+
+const FAB_HIDE_MARGIN = 130;
+
+type LinkType = 'blog' | 'internal' | 'projects' | 'social';
+
+const LINK_ICON: Record<LinkType, React.ReactNode> = {
+	blog: <LuFileText className="w-[17px] h-[17px]" />,
+	internal: <LuNavigation className="w-[17px] h-[17px]" />,
+	projects: <LuLayers className="w-[17px] h-[17px]" />,
+	social: <LuExternalLink className="w-[17px] h-[17px]" />
+};
+
+interface Link {
+	url: string;
+	title: string;
+	type: LinkType;
+}
+
+const LinkGroup = ({
+	heading,
+	links,
+	onSelect
+}: {
+	heading: string;
+	links: Link[];
+	onSelect: (url: string) => void;
+}) => (
+	<CommandGroup heading={heading}>
+		{links.map(({ url, title, type }) => (
+			<CommandItem key={url} onSelect={() => onSelect(url)}>
+				<span className="w-[17px] h-[17px] text-muted-foreground grid place-items-center shrink-0">
+					{LINK_ICON[type]}
+				</span>
+				<span>{title}</span>
+			</CommandItem>
+		))}
+	</CommandGroup>
+);
 
 interface Props {
-	links: {
-		url: string;
-		title: string;
-		type: string;
-	}[];
+	links: Link[];
 }
 
 export const CommandMenu = ({ links }: Props) => {
 	const [open, setOpen] = useState(false);
+	const [fabHidden, setFabHidden] = useState(false);
 	const navigate = useNavigate();
 
 	const internalLinks = links.filter((link) => link.type === 'internal');
@@ -32,83 +70,91 @@ export const CommandMenu = ({ links }: Props) => {
 		const down = (e: KeyboardEvent) => {
 			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
 				e.preventDefault();
-				setOpen((prevState) => !prevState);
+				setOpen((prev) => !prev);
 			}
 		};
 		document.addEventListener('keydown', down);
 		return () => document.removeEventListener('keydown', down);
 	}, []);
 
+	useLenis(({ scroll }) => {
+		const doc = document.documentElement;
+		setFabHidden(scroll + doc.clientHeight > doc.scrollHeight - FAB_HIDE_MARGIN);
+	});
+
 	return (
 		<>
-			<div className="hidden md:inline fixed bottom-0 left-0 right-0 p-1 print:hidden border-t border-t-muted-foreground dark:border-b-[#4D2512] from-white-600/30 dark:from-teal-200/30 via-white dark:via-black to-slate-600/30 dark:to-slate-600/30 backdrop-blur-xs">
-				<p className="text-center text-sm text-muted-foreground">
-					Press{' '}
-					<kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
-						<span className="text-xs">⌘</span>K
-					</kbd>{' '}
-					to open the command menu
-				</p>
-			</div>
+			<button
+				className={cn(
+					'fixed left-1/2 bottom-[22px] -translate-x-1/2 z-[55] print:hidden',
+					'flex items-center gap-[10px]',
+					'font-mono text-[12px] text-muted-foreground',
+					'pl-[15px] pr-3 py-[9px] rounded-full',
+					'border border-border',
+					'bg-[color-mix(in_srgb,hsl(var(--card))_82%,transparent)]',
+					'[backdrop-filter:blur(12px)_saturate(1.2)]',
+					'shadow-[0_14px_38px_-12px_rgba(0,0,0,0.34)]',
+					'cursor-pointer',
+					'transition-[translate,opacity,box-shadow,color] duration-[450ms] [transition-timing-function:var(--ease-out)]',
+					'hover:text-foreground hover:-translate-y-[3px] hover:shadow-[0_22px_46px_-14px_rgba(0,0,0,0.42)]',
+					fabHidden
+						? 'opacity-0 translate-y-[140%] pointer-events-none'
+						: 'opacity-100 translate-y-0'
+				)}
+				onClick={() => setOpen(true)}
+				aria-label="Open command menu"
+			>
+				<LuSearch className="w-[14px] h-[14px] shrink-0" />
+				<span className="max-[480px]:hidden">search & jump anywhere</span>
+				<span className="flex gap-[3px]">
+					<kbd className="font-mono text-[10px] border border-border rounded-[4px] px-[5px] py-[3px] bg-background text-foreground leading-none">
+						⌘
+					</kbd>
+					<kbd className="font-mono text-[10px] border border-border rounded-[4px] px-[5px] py-[3px] bg-background text-foreground leading-none">
+						K
+					</kbd>
+				</span>
+			</button>
+
 			<CommandDialog open={open} onOpenChange={setOpen}>
-				<CommandInput placeholder="Type a command or search..." />
+				<CommandInput placeholder="Type a command or search…" />
 				<CommandList>
 					<CommandEmpty>No results found.</CommandEmpty>
-					<CommandGroup heading="Links">
-						{internalLinks.map(({ url, title }) => (
-							<CommandItem
-								key={url}
-								onSelect={() => {
-									setOpen(false);
-									void navigate({ to: url });
-								}}
-							>
-								<span>{title}</span>
-							</CommandItem>
-						))}
-					</CommandGroup>
+					<LinkGroup
+						heading="Links"
+						links={internalLinks}
+						onSelect={(url) => {
+							setOpen(false);
+							void navigate({ to: url });
+						}}
+					/>
 					<CommandSeparator />
-					<CommandGroup heading="Projects">
-						{projectsLinks.map(({ url, title }) => (
-							<CommandItem
-								key={url}
-								onSelect={() => {
-									setOpen(false);
-									void navigate({ to: url });
-								}}
-							>
-								<span>{title}</span>
-							</CommandItem>
-						))}
-					</CommandGroup>
+					<LinkGroup
+						heading="Projects"
+						links={projectsLinks}
+						onSelect={(url) => {
+							setOpen(false);
+							void navigate({ to: url });
+						}}
+					/>
 					<CommandSeparator />
-					<CommandGroup heading="Blog">
-						{blogLinks.map(({ url, title }) => (
-							<CommandItem
-								key={url}
-								onSelect={() => {
-									setOpen(false);
-									void navigate({ to: url });
-								}}
-							>
-								<span>{title}</span>
-							</CommandItem>
-						))}
-					</CommandGroup>
+					<LinkGroup
+						heading="Blog"
+						links={blogLinks}
+						onSelect={(url) => {
+							setOpen(false);
+							void navigate({ to: url });
+						}}
+					/>
 					<CommandSeparator />
-					<CommandGroup heading="Socials">
-						{socialsLinks.map(({ url, title }) => (
-							<CommandItem
-								key={url}
-								onSelect={() => {
-									setOpen(false);
-									window.open(url);
-								}}
-							>
-								<span>{title}</span>
-							</CommandItem>
-						))}
-					</CommandGroup>
+					<LinkGroup
+						heading="Socials"
+						links={socialsLinks}
+						onSelect={(url) => {
+							setOpen(false);
+							window.open(url);
+						}}
+					/>
 				</CommandList>
 			</CommandDialog>
 		</>

--- a/src/components/now-playing.tsx
+++ b/src/components/now-playing.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { NowPlayingData } from '@/server/routes/api/types/spotify';
 
@@ -30,7 +30,6 @@ function HeadphonesIcon() {
 
 export const NowPlaying = () => {
 	const [tick, setTick] = useState(0);
-	const artRef = useRef<HTMLSpanElement>(null);
 
 	const { data: nowPlaying } = useQuery<{ data: NowPlayingData }>({
 		queryKey: ['nowPlaying'],
@@ -47,28 +46,6 @@ export const NowPlaying = () => {
 		return () => clearInterval(id);
 	}, [isPlaying]);
 
-	useEffect(() => {
-		const el = artRef.current;
-		if (!el) return;
-		if (!isPlaying || !albumImageUrl) {
-			el.style.boxShadow = '';
-			return;
-		}
-		const img = new Image();
-		img.crossOrigin = 'anonymous';
-		img.src = albumImageUrl;
-		img.onload = () => {
-			const canvas = document.createElement('canvas');
-			canvas.width = 1;
-			canvas.height = 1;
-			const ctx = canvas.getContext('2d');
-			if (!ctx || !artRef.current) return;
-			ctx.drawImage(img, 0, 0, 1, 1);
-			const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
-			artRef.current.style.boxShadow = `0 4px 10px -2px rgba(${r},${g},${b},0.5)`;
-		};
-	}, [isPlaying, albumImageUrl]);
-
 	const heights = EQ_FRAMES[tick % 4] ?? EQ_FRAMES[0];
 	const href = isPlaying ? nowPlaying?.data.songUrl : 'https://open.spotify.com';
 
@@ -84,16 +61,25 @@ export const NowPlaying = () => {
 					: 'Not playing — right now'
 			}
 		>
-			<span
-				ref={artRef}
-				className={`relative w-[42px] h-[42px] rounded-[9px] shrink-0 grid place-items-center overflow-hidden transition-[scale,box-shadow] duration-[450ms] [transition-timing-function:var(--ease-out)] group-hover:scale-[1.05] [&_img]:w-full [&_img]:h-full [&_img]:object-cover [&_img]:block [&_svg]:w-[22px] [&_svg]:h-[22px] ${isPlaying ? 'text-white bg-[linear-gradient(140deg,#1ed760,#169c46_55%,#0c6b30)]' : 'text-muted-foreground bg-muted'}`}
-			>
-				{isPlaying && nowPlaying?.data.albumImageUrl ? (
-					<img src={nowPlaying.data.albumImageUrl} alt={nowPlaying.data.album || 'Album cover'} />
-				) : (
-					<HeadphonesIcon />
+			<div className="relative shrink-0">
+				{isPlaying && albumImageUrl && (
+					<img
+						src={albumImageUrl}
+						className="absolute inset-0 w-full h-full object-cover blur-[8px] scale-[1.2] opacity-40 rounded-[9px] motion-reduce:hidden pointer-events-none"
+						aria-hidden="true"
+					/>
 				)}
-			</span>
+				<span
+					className={`relative w-[42px] h-[42px] rounded-[9px] grid place-items-center overflow-hidden transition-scale duration-[450ms] [transition-timing-function:var(--ease-out)] group-hover:scale-[1.05] [&_img]:w-full [&_img]:h-full [&_img]:object-cover [&_img]:block [&_svg]:w-[22px] [&_svg]:h-[22px] ${isPlaying ? 'text-white bg-[linear-gradient(140deg,#1ed760,#169c46_55%,#0c6b30)]' : 'text-muted-foreground bg-muted'}`}
+				>
+					{isPlaying && albumImageUrl ? (
+						<img src={albumImageUrl} alt={nowPlaying.data.album || 'Album cover'} />
+					) : (
+						<HeadphonesIcon />
+					)}
+				</span>
+			</div>
+
 			<span className="flex flex-col min-w-0 flex-1">
 				<span className="flex items-center gap-2 mb-[3px]">
 					<span className="flex gap-[2px] items-end h-[13px]">

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,9 +1,10 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
 import * as React from 'react';
 import { LuSearch } from 'react-icons/lu';
 
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { DialogOverlay, DialogPortal } from '@/components/ui/dialog';
 import { cn } from '@/utils/utils';
 
 const Command = React.forwardRef<
@@ -12,10 +13,7 @@ const Command = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<CommandPrimitive
 		ref={ref}
-		className={cn(
-			'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-			className
-		)}
+		className={cn('flex h-full w-full flex-col overflow-hidden', className)}
 		{...props}
 	/>
 ));
@@ -25,13 +23,25 @@ interface CommandDialogProps extends DialogProps {}
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
 	return (
-		<Dialog {...props}>
-			<DialogContent className="overflow-hidden p-0 shadow-lg">
-				<Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-					{children}
-				</Command>
-			</DialogContent>
-		</Dialog>
+		<DialogPrimitive.Root {...props}>
+			<DialogPortal>
+				<DialogOverlay className="bg-foreground/[0.22] backdrop-blur-[4px]" />
+				<DialogPrimitive.Content
+					className={cn(
+						'fixed left-[50%] top-[14vh] z-50 w-[min(540px,92vw)] translate-x-[-50%]',
+						'rounded-[14px] border border-border overflow-hidden',
+						'bg-[color-mix(in_srgb,hsl(var(--card))_96%,transparent)]',
+						'shadow-[0_40px_80px_-20px_rgba(0,0,0,0.45)]',
+						'data-[state=open]:animate-in data-[state=closed]:animate-out',
+						'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+						'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+						'data-[state=open]:slide-in-from-top-2'
+					)}
+				>
+					<Command>{children}</Command>
+				</DialogPrimitive.Content>
+			</DialogPortal>
+		</DialogPrimitive.Root>
 	);
 };
 
@@ -39,16 +49,22 @@ const CommandInput = React.forwardRef<
 	React.ElementRef<typeof CommandPrimitive.Input>,
 	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-	<div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-		<LuSearch className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+	<div
+		className="flex items-center gap-[10px] px-4 py-[15px] border-b border-border"
+		cmdk-input-wrapper=""
+	>
+		<LuSearch className="w-4 h-4 shrink-0 text-muted-foreground" />
 		<CommandPrimitive.Input
 			ref={ref}
 			className={cn(
-				'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+				'flex flex-1 bg-transparent font-mono text-[14px] text-foreground outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
 				className
 			)}
 			{...props}
 		/>
+		<span className="font-mono text-[10px] border border-border rounded-[5px] px-[6px] py-[3px] text-muted-foreground shrink-0 leading-none">
+			esc
+		</span>
 	</div>
 ));
 
@@ -60,7 +76,7 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
 	<CommandPrimitive.List
 		ref={ref}
-		className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+		className={cn('max-h-[320px] overflow-y-auto overflow-x-hidden p-2', className)}
 		{...props}
 	/>
 ));
@@ -71,7 +87,11 @@ const CommandEmpty = React.forwardRef<
 	React.ElementRef<typeof CommandPrimitive.Empty>,
 	React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
 >((props, ref) => (
-	<CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+	<CommandPrimitive.Empty
+		ref={ref}
+		className="py-6 text-center font-mono text-[12px] text-muted-foreground"
+		{...props}
+	/>
 ));
 
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
@@ -83,7 +103,11 @@ const CommandGroup = React.forwardRef<
 	<CommandPrimitive.Group
 		ref={ref}
 		className={cn(
-			'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+			'overflow-hidden text-foreground',
+			'[&_[cmdk-group-heading]]:px-[10px] [&_[cmdk-group-heading]]:pt-2 [&_[cmdk-group-heading]]:pb-1',
+			'[&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:text-[10px]',
+			'[&_[cmdk-group-heading]]:tracking-[0.1em] [&_[cmdk-group-heading]]:uppercase',
+			'[&_[cmdk-group-heading]]:text-muted-foreground',
 			className
 		)}
 		{...props}
@@ -111,7 +135,10 @@ const CommandItem = React.forwardRef<
 	<CommandPrimitive.Item
 		ref={ref}
 		className={cn(
-			'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-hidden aria-selected:bg-accent aria-selected:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+			'relative flex cursor-default select-none items-center gap-3 rounded-[9px] px-3 py-[10px]',
+			'font-mono text-[13px] text-foreground outline-none',
+			'aria-selected:bg-[color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)]',
+			'data-disabled:pointer-events-none data-disabled:opacity-50',
 			className
 		)}
 		{...props}
@@ -120,24 +147,12 @@ const CommandItem = React.forwardRef<
 
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
-const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
-	return (
-		<span
-			className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
-			{...props}
-		/>
-	);
-};
-CommandShortcut.displayName = 'CommandShortcut';
-
 export {
-	// Command,
 	CommandDialog,
 	CommandEmpty,
 	CommandGroup,
 	CommandInput,
 	CommandItem,
 	CommandList,
-	// CommandShortcut,
 	CommandSeparator
 };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -84,17 +84,4 @@ const DialogDescription = React.forwardRef<
 ));
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
-export {
-	Dialog,
-	DialogContent
-	/* 	
-	DialogPortal,
-	DialogOverlay,
-	DialogClose,
-	DialogTrigger,
-	DialogHeader,
-	DialogFooter,
-	DialogTitle,
-	DialogDescription 
-		*/
-};
+export { Dialog, DialogContent, DialogOverlay, DialogPortal };


### PR DESCRIPTION
## What

- Replaced the bottom bar command menu hint with a floating pill FAB (glassmorphism, hide-on-bottom-scroll via `useLenis`)
- Restyled `CommandDialog` to top-positioned sheet with custom backdrop blur overlay, orange-tinted selection, mono font throughout, and `esc` badge in input
- Added per-link-type icons to all `CommandItem` entries; extracted repeated group rendering into `LinkGroup` helper; narrowed `type` prop to a union
- Replaced canvas color-extraction glow on `NowPlaying` with a CSS blur-copy of the album art (`blur-[8px] scale-[1.2] opacity-40`), eliminating CORS risk and canvas overhead; `motion-reduce:hidden` on the glow for accessibility
- Exported `DialogPortal` and `DialogOverlay` from `dialog.tsx` for reuse in `command.tsx`

## Linear
Closes PER-12

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally