### PR TITLE
Add reusable CMS object schemas (PER-16)

### DIFF
--- a/cms/schemaTypes/index.ts
+++ b/cms/schemaTypes/index.ts
@@ -1,4 +1,19 @@
+import {bodyType} from './objects/body-type'
+import {galleryItemType} from './objects/gallery-item-type'
+import {linkType} from './objects/link-type'
+import {metricType} from './objects/metric-type'
+import {richImageType} from './objects/rich-image-type'
+import {seoType} from './objects/seo-type'
 import {postType} from './post-type'
 import {projectType} from './project-type'
 
-export const schemaTypes = [postType, projectType]
+export const schemaTypes = [
+  seoType,
+  richImageType,
+  metricType,
+  galleryItemType,
+  linkType,
+  bodyType,
+  postType,
+  projectType
+]

--- a/cms/schemaTypes/objects/body-type.ts
+++ b/cms/schemaTypes/objects/body-type.ts
@@ -1,0 +1,121 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+export const bodyType = defineType({
+  name: 'body',
+  title: 'Body',
+  type: 'array',
+  of: [
+    defineArrayMember({
+      type: 'block',
+      styles: [
+        {title: 'Normal', value: 'normal'},
+        {title: 'H2', value: 'h2'},
+        {title: 'H3', value: 'h3'},
+        {title: 'H4', value: 'h4'},
+        {title: 'Quote', value: 'blockquote'}
+      ],
+      lists: [
+        {title: 'Bullet', value: 'bullet'},
+        {title: 'Numbered', value: 'number'}
+      ],
+      marks: {
+        decorators: [
+          {title: 'Bold', value: 'strong'},
+          {title: 'Italic', value: 'em'},
+          {title: 'Code', value: 'code'}
+        ],
+        annotations: [
+          {
+            name: 'link',
+            type: 'object',
+            title: 'Link',
+            fields: [
+              defineField({
+                name: 'href',
+                type: 'url',
+                title: 'URL',
+                validation: (rule) =>
+                  rule.uri({allowRelative: true, scheme: ['http', 'https', 'mailto']})
+              })
+            ]
+          }
+        ]
+      }
+    }),
+    defineArrayMember({
+      type: 'richImage'
+    }),
+    defineArrayMember({
+      name: 'code',
+      title: 'Code Block',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'language',
+          title: 'Language',
+          type: 'string',
+          options: {
+            list: [
+              {title: 'TypeScript', value: 'typescript'},
+              {title: 'JavaScript', value: 'javascript'},
+              {title: 'HTML', value: 'html'},
+              {title: 'CSS', value: 'css'},
+              {title: 'JSON', value: 'json'},
+              {title: 'Go', value: 'go'},
+              {title: 'Bash', value: 'bash'},
+              {title: 'SQL', value: 'sql'},
+              {title: 'Plain text', value: 'text'}
+            ]
+          }
+        }),
+        defineField({
+          name: 'filename',
+          title: 'Filename',
+          type: 'string',
+          description: 'Optional filename shown in the code bar.'
+        }),
+        defineField({
+          name: 'code',
+          title: 'Code',
+          type: 'text',
+          rows: 12,
+          validation: (rule) => rule.required()
+        })
+      ],
+      preview: {
+        select: {title: 'filename', subtitle: 'language'},
+        prepare({title, subtitle}) {
+          return {title: title || 'Code block', subtitle: subtitle || 'plain text'}
+        }
+      }
+    }),
+    defineArrayMember({
+      name: 'pullQuote',
+      title: 'Pull Quote',
+      type: 'object',
+      fields: [
+        defineField({
+          name: 'text',
+          title: 'Quote Text',
+          type: 'text',
+          rows: 3,
+          validation: (rule) => rule.required()
+        }),
+        defineField({
+          name: 'attribution',
+          title: 'Attribution',
+          type: 'string'
+        })
+      ],
+      preview: {
+        select: {title: 'text', subtitle: 'attribution'},
+        prepare({title, subtitle}) {
+          return {
+            title: title ? `"${title.slice(0, 60)}…"` : 'Pull quote',
+            subtitle: subtitle || ''
+          }
+        }
+      }
+    })
+  ]
+})

--- a/cms/schemaTypes/objects/gallery-item-type.ts
+++ b/cms/schemaTypes/objects/gallery-item-type.ts
@@ -1,0 +1,38 @@
+import {defineField, defineType} from 'sanity'
+
+export const galleryItemType = defineType({
+  name: 'galleryItem',
+  title: 'Gallery Item',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'image',
+      title: 'Image',
+      type: 'richImage',
+      validation: (rule) => rule.required()
+    }),
+    defineField({
+      name: 'layout',
+      title: 'Layout',
+      type: 'string',
+      description: 'Controls how the item spans the gallery grid.',
+      options: {
+        list: [
+          {title: 'Full width (16:8)', value: 'wide'},
+          {title: 'Half (4:3)', value: 'half'},
+          {title: 'Third (3:4)', value: 'third'}
+        ],
+        layout: 'radio'
+      },
+      initialValue: 'half',
+      validation: (rule) => rule.required()
+    })
+  ],
+  preview: {
+    select: {
+      title: 'image.alt',
+      subtitle: 'layout',
+      media: 'image'
+    }
+  }
+})

--- a/cms/schemaTypes/objects/link-type.ts
+++ b/cms/schemaTypes/objects/link-type.ts
@@ -1,0 +1,26 @@
+import {defineField, defineType} from 'sanity'
+
+export const linkType = defineType({
+  name: 'link',
+  title: 'Link',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      description: 'Display label for the link.',
+      validation: (rule) => rule.required()
+    }),
+    defineField({
+      name: 'url',
+      title: 'URL',
+      type: 'url',
+      validation: (rule) =>
+        rule.required().uri({allowRelative: true, scheme: ['http', 'https', 'mailto']})
+    })
+  ],
+  preview: {
+    select: {title: 'title', subtitle: 'url'}
+  }
+})

--- a/cms/schemaTypes/objects/metric-type.ts
+++ b/cms/schemaTypes/objects/metric-type.ts
@@ -1,0 +1,26 @@
+import {defineField, defineType} from 'sanity'
+
+export const metricType = defineType({
+  name: 'metric',
+  title: 'Metric',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'value',
+      title: 'Value',
+      type: 'string',
+      description: 'The prominent figure, e.g. "300+", "<80ms", "0".',
+      validation: (rule) => rule.required()
+    }),
+    defineField({
+      name: 'label',
+      title: 'Label',
+      type: 'string',
+      description: 'Short description beneath the value.',
+      validation: (rule) => rule.required()
+    })
+  ],
+  preview: {
+    select: {title: 'value', subtitle: 'label'}
+  }
+})

--- a/cms/schemaTypes/objects/rich-image-type.ts
+++ b/cms/schemaTypes/objects/rich-image-type.ts
@@ -1,0 +1,23 @@
+import {defineField, defineType} from 'sanity'
+
+export const richImageType = defineType({
+  name: 'richImage',
+  title: 'Rich Image',
+  type: 'image',
+  options: {hotspot: true},
+  fields: [
+    defineField({
+      name: 'alt',
+      title: 'Alt Text',
+      type: 'string',
+      description: 'Describe the image for screen readers and search engines.',
+      validation: (rule) => rule.required().error('Alt text is required for accessibility.')
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      type: 'string',
+      description: 'Optional visible caption displayed beneath the image.'
+    })
+  ]
+})

--- a/cms/schemaTypes/objects/seo-type.ts
+++ b/cms/schemaTypes/objects/seo-type.ts
@@ -1,0 +1,31 @@
+import {defineField, defineType} from 'sanity'
+
+export const seoType = defineType({
+  name: 'seo',
+  title: 'SEO',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Meta Title',
+      type: 'string',
+      description: 'Overrides the document title for search engines and social previews.',
+      validation: (rule) => rule.max(70).warning('Keep under 70 characters for best display.')
+    }),
+    defineField({
+      name: 'description',
+      title: 'Meta Description',
+      type: 'text',
+      rows: 3,
+      description: 'Overrides the document description for search engines and social previews.',
+      validation: (rule) => rule.max(160).warning('Keep under 160 characters for best display.')
+    }),
+    defineField({
+      name: 'ogImage',
+      title: 'Open Graph Image',
+      type: 'image',
+      description: 'Recommended 1200×630. Falls back to the document cover/hero if empty.',
+      options: {hotspot: true}
+    })
+  ]
+})


### PR DESCRIPTION
## What
Add six reusable Sanity CMS object schemas that serve as building blocks for document types:

- **seo** — meta title (max 70), description (max 160), OG image with hotspot
- **richImage** — image with required alt text, optional caption, hotspot support
- **metric** — prominent value + label for stats cards
- **galleryItem** — richImage + layout hint (wide/half/third) for grid spanning
- **link** — title + URL with URI validation (http/https/mailto/relative)
- **body** — Portable Text with h2–h4, blockquote, lists, marks, link annotations, richImage embeds, code blocks (language/filename/code), and pull quotes (text/attribution)

All types registered in `cms/schemaTypes/index.ts`. Validated with `sanity schema extract` and `pnpm validate`.

## Linear
Closes PER-16

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally