### PR TITLE
Expand structured post schema (PER-18)

### DIFF
--- a/cms/schemaTypes/post-type.ts
+++ b/cms/schemaTypes/post-type.ts
@@ -4,17 +4,25 @@ export const postType = defineType({
   name: 'post',
   title: 'Post',
   type: 'document',
+  groups: [
+    {name: 'content', title: 'Content', default: true},
+    {name: 'meta', title: 'Meta & Tags'},
+    {name: 'seo', title: 'SEO'}
+  ],
   fields: [
+    // ── Core identity ──────────────────────────────────────────────
     defineField({
       name: 'title',
       title: 'Title',
       type: 'string',
+      group: 'content',
       validation: (rule) => rule.required()
     }),
     defineField({
       name: 'slug',
       title: 'Slug',
       type: 'slug',
+      group: 'content',
       options: {source: 'title'},
       validation: (rule) => rule.required()
     }),
@@ -23,42 +31,139 @@ export const postType = defineType({
       title: 'Description',
       type: 'text',
       rows: 3,
+      group: 'content',
       validation: (rule) => rule.required()
     }),
     defineField({
       name: 'date',
-      title: 'Date',
+      title: 'Publication Date',
       type: 'datetime',
+      group: 'content',
       validation: (rule) => rule.required()
     }),
     defineField({
-      name: 'keywords',
-      title: 'Keywords',
-      type: 'array',
-      of: [{type: 'string'}]
-    }),
-    defineField({
-      name: 'link',
-      title: 'External Link',
-      type: 'url'
-    }),
-    defineField({
-      name: 'id',
-      title: 'Legacy ID',
-      type: 'string'
+      name: 'featured',
+      title: 'Featured',
+      type: 'boolean',
+      group: 'content',
+      description: 'Highlight this post on the homepage or journal index.',
+      initialValue: false
     }),
     defineField({
       name: 'published',
       title: 'Published',
       type: 'boolean',
+      group: 'content',
       initialValue: true
     }),
+
+    // ── Media ──────────────────────────────────────────────────────
+    defineField({
+      name: 'coverImage',
+      title: 'Cover Image',
+      type: 'richImage',
+      group: 'content',
+      description: 'Hero/cover image shown on the index card and article header.'
+    }),
+
+    // ── Structured body ────────────────────────────────────────────
+    defineField({
+      name: 'structuredBody',
+      title: 'Structured Body',
+      type: 'body',
+      group: 'content',
+      description: 'Rich article content. Replaces the legacy MDX body.'
+    }),
+
+    // ── Meta & Tags ────────────────────────────────────────────────
+    defineField({
+      name: 'category',
+      title: 'Category',
+      type: 'string',
+      group: 'meta',
+      options: {
+        list: [
+          {title: 'Engineering', value: 'engineering'},
+          {title: 'Design', value: 'design'},
+          {title: 'Career', value: 'career'},
+          {title: 'Tutorial', value: 'tutorial'},
+          {title: 'Reflection', value: 'reflection'}
+        ],
+        layout: 'dropdown'
+      }
+    }),
+    defineField({
+      name: 'tags',
+      title: 'Tags',
+      type: 'array',
+      of: [{type: 'string'}],
+      group: 'meta',
+      options: {layout: 'tags'},
+      description: 'Normalized lowercase tags for filtering and display.'
+    }),
+    defineField({
+      name: 'author',
+      title: 'Author',
+      type: 'object',
+      group: 'meta',
+      fields: [
+        defineField({
+          name: 'name',
+          title: 'Name',
+          type: 'string',
+          validation: (rule) => rule.required()
+        }),
+        defineField({
+          name: 'avatar',
+          title: 'Avatar',
+          type: 'image',
+          options: {hotspot: true}
+        }),
+        defineField({
+          name: 'url',
+          title: 'Profile URL',
+          type: 'url'
+        })
+      ]
+    }),
+    defineField({
+      name: 'canonicalUrl',
+      title: 'Canonical URL',
+      type: 'url',
+      group: 'meta',
+      description: 'If this post was originally published elsewhere, set the canonical URL.'
+    }),
+
+    // ── Legacy fields (kept for migration) ─────────────────────────
     defineField({
       name: 'body',
-      title: 'Body',
+      title: 'Body — MDX (legacy)',
       type: 'text',
       rows: 20,
-      validation: (rule) => rule.required()
+      group: 'content',
+      deprecated: {reason: 'Use structuredBody instead.'}
+    }),
+    defineField({
+      name: 'keywords',
+      title: 'Keywords (legacy)',
+      type: 'array',
+      of: [{type: 'string'}],
+      group: 'meta',
+      deprecated: {reason: 'Use tags instead.'}
+    }),
+    defineField({
+      name: 'link',
+      title: 'External Link (legacy)',
+      type: 'url',
+      group: 'meta',
+      deprecated: {reason: 'Use canonicalUrl instead.'}
+    }),
+    defineField({
+      name: 'id',
+      title: 'Legacy ID',
+      type: 'string',
+      group: 'meta',
+      deprecated: {reason: 'No longer needed after migration.'}
     }),
     defineField({
       name: 'views',
@@ -67,6 +172,50 @@ export const postType = defineType({
       initialValue: 0,
       readOnly: true,
       hidden: true
+    }),
+
+    // ── SEO ────────────────────────────────────────────────────────
+    defineField({
+      name: 'seo',
+      title: 'SEO',
+      type: 'seo',
+      group: 'seo'
     })
+  ],
+  preview: {
+    select: {
+      title: 'title',
+      subtitle: 'category',
+      date: 'date',
+      featured: 'featured',
+      media: 'coverImage'
+    },
+    prepare({title, subtitle, date, featured, media}) {
+      const prefix = featured ? '★ ' : ''
+      const formattedDate = date
+        ? new Date(date).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+          })
+        : ''
+      return {
+        title: `${prefix}${title}`,
+        subtitle: [subtitle, formattedDate].filter(Boolean).join(' · '),
+        media
+      }
+    }
+  },
+  orderings: [
+    {
+      title: 'Publication Date (newest)',
+      name: 'dateDesc',
+      by: [{field: 'date', direction: 'desc'}]
+    },
+    {
+      title: 'Publication Date (oldest)',
+      name: 'dateAsc',
+      by: [{field: 'date', direction: 'asc'}]
+    }
   ]
 })


### PR DESCRIPTION
## What
Expand the Sanity post document schema to model all v2 journal content, organized into Studio tab groups:

- **Content** — `featured` flag, `coverImage` (richImage), `structuredBody` (Portable Text replacing legacy MDX body)
- **Meta & Tags** — `category` (dropdown: engineering/design/career/tutorial/reflection), `tags` (normalized tag input), `author` (name/avatar/url object), `canonicalUrl`
- **SEO** — reusable `seo` object (meta title, description, OG image)

Legacy fields (`body`, `keywords`, `link`, `id`) preserved with `deprecated` markers for migration safety. Studio preview shows featured star prefix, category + date subtitle, and cover image thumbnail. Added date-based sort orderings.

## Linear
Closes PER-18

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally