### PR TITLE
Add typed GROQ projections and Sanity image resolution (PER-20)

### DIFF
--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -1,4 +1,13 @@
 import { fetchSanityQuery } from '@/lib/sanity';
+import type {
+	PortableTextBody,
+	ResolvedAuthor,
+	ResolvedImage,
+	ResolvedSeo
+} from '@/lib/sanity-types';
+import { AUTHOR_PROJECTION, RICH_IMAGE_PROJECTION, SEO_PROJECTION } from '@/lib/sanity-types';
+
+// ── Helpers ───────────────────────────────────────────────────────────
 
 const WORDS_PER_MINUTE = 200;
 
@@ -7,47 +16,76 @@ function calculateReadingTime(text: string): number {
 	return Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
 }
 
-export interface BlogPost {
-	title: string;
-	description: string;
-	date: string;
-	slug: string;
-	body: string;
-	external_link: string;
-	keywords: string[];
-	cover?: string;
-	category?: string;
-	featured?: boolean;
-	readingTime?: number;
-}
-
-type SanityBlogPost = {
-	title: string;
-	description: string;
-	date: string;
-	slug: string;
-	body?: string;
-	link?: string;
-	keywords?: string[];
-	published?: boolean;
-	cover?: string;
-	category?: string;
-	featured?: boolean;
-};
+// ── GROQ projections ──────────────────────────────────────────────────
 
 const POST_FIELDS = `
   title,
   description,
   date,
   "slug": slug.current,
+  published,
+  featured,
+  category,
+  "tags": tags,
+  "coverImage": coverImage ${RICH_IMAGE_PROJECTION},
+  "author": author ${AUTHOR_PROJECTION},
+  canonicalUrl,
+  structuredBody,
+  "seo": seo ${SEO_PROJECTION},
+  // Legacy fields — still projected until migration completes
   body,
   link,
   keywords,
-  published,
-  "cover": cover.asset->url,
-  category,
-  featured
+  "cover": cover.asset->url
 `;
+
+// ── Sanity response types ─────────────────────────────────────────────
+
+type SanityBlogPost = {
+	title: string;
+	description: string;
+	date: string;
+	slug: string;
+	published?: boolean;
+	featured?: boolean;
+	category?: string;
+	tags?: string[];
+	coverImage?: ResolvedImage;
+	author?: ResolvedAuthor;
+	canonicalUrl?: string;
+	structuredBody?: PortableTextBody;
+	seo?: ResolvedSeo;
+	// Legacy
+	body?: string;
+	link?: string;
+	keywords?: string[];
+	cover?: string;
+};
+
+// ── Application model ─────────────────────────────────────────────────
+
+export interface BlogPost {
+	title: string;
+	description: string;
+	date: string;
+	slug: string;
+	featured: boolean;
+	category?: string;
+	tags: string[];
+	coverImage?: ResolvedImage;
+	author?: ResolvedAuthor;
+	canonicalUrl?: string;
+	structuredBody?: PortableTextBody;
+	seo?: ResolvedSeo;
+	readingTime?: number;
+	// Legacy — available until migration completes
+	body: string;
+	external_link: string;
+	keywords: string[];
+	cover?: string;
+}
+
+// ── Normalizer ────────────────────────────────────────────────────────
 
 function normalizePost(post: SanityBlogPost): BlogPost {
 	const body = post.body ?? '';
@@ -56,21 +94,29 @@ function normalizePost(post: SanityBlogPost): BlogPost {
 		description: post.description,
 		date: post.date,
 		slug: post.slug,
+		featured: post.featured ?? false,
+		category: post.category,
+		tags: Array.isArray(post.tags) ? post.tags : [],
+		coverImage: post.coverImage,
+		author: post.author,
+		canonicalUrl: post.canonicalUrl,
+		structuredBody: post.structuredBody,
+		seo: post.seo,
+		readingTime: body ? calculateReadingTime(body) : undefined,
+		// Legacy
 		body,
 		external_link: post.link ?? '',
 		keywords: Array.isArray(post.keywords) ? post.keywords.map((w) => `#${w}`) : [],
-		cover: post.cover,
-		category: post.category,
-		featured: post.featured ?? false,
-		readingTime: body ? calculateReadingTime(body) : undefined
+		cover: post.coverImage?.url ?? post.cover
 	};
 }
+
+// ── Queries ───────────────────────────────────────────────────────────
 
 export const getPosts = async () => {
 	const posts = await fetchSanityQuery<SanityBlogPost[]>(
 		`*[_type == "post" && published != false] | order(date desc) { ${POST_FIELDS} }`
 	);
-
 	return posts.map(normalizePost);
 };
 
@@ -79,7 +125,6 @@ export async function getPost(slug: string) {
 		`*[_type == "post" && slug.current == $slug][0]{ ${POST_FIELDS} }`,
 		{ slug }
 	);
-
 	return post ? normalizePost(post) : undefined;
 }
 
@@ -90,10 +135,10 @@ export async function getPostViews(slug: string) {
 		views: number;
 	} | null>(
 		`*[_type == "post" && slug.current == $slug][0]{
-			"postId": _id,
-			"metricId": *[_type == "postMetric" && references(^._id)][0]._id,
-			"views": coalesce(*[_type == "postMetric" && references(^._id)][0].views, 0)
-		}`,
+      "postId": _id,
+      "metricId": *[_type == "postMetric" && references(^._id)][0]._id,
+      "views": coalesce(*[_type == "postMetric" && references(^._id)][0].views, 0)
+    }`,
 		{ slug }
 	);
 	return result;

--- a/src/data/projects/index.ts
+++ b/src/data/projects/index.ts
@@ -1,88 +1,162 @@
 import { fetchSanityQuery } from '@/lib/sanity';
+import type {
+	PortableTextBody,
+	ResolvedGalleryItem,
+	ResolvedImage,
+	ResolvedLink,
+	ResolvedMetric,
+	ResolvedSeo
+} from '@/lib/sanity-types';
+import {
+	GALLERY_ITEM_PROJECTION,
+	LINK_PROJECTION,
+	RICH_IMAGE_PROJECTION,
+	SEO_PROJECTION
+} from '@/lib/sanity-types';
+
+// ── GROQ projections ──────────────────────────────────────────────────
 
 const PROJECT_FIELDS = `
-  hero,
   title,
   description,
   year,
   displayOrder,
+  featured,
+  "slug": slug.current,
+  medium,
   role,
   timeline,
   context,
-  "slug": slug.current,
-  repo,
-  liveUrl,
-  medium,
+  technologies,
   tags,
   colors,
-  technologies,
-  body,
-  published
+  published,
+  "coverImage": coverImage ${RICH_IMAGE_PROJECTION},
+  "links": links[] ${LINK_PROJECTION},
+  overview,
+  problem,
+  approach,
+  "statistics": statistics[] { value, label },
+  "gallery": gallery[] ${GALLERY_ITEM_PROJECTION},
+  structuredBody,
+  "seo": seo ${SEO_PROJECTION},
+  // Legacy fields — still projected until migration completes
+  hero,
+  repo,
+  liveUrl,
+  body
 `;
 
+const NEXT_PROJECT_FIELDS = `
+  title,
+  "slug": slug.current,
+  colors,
+  "coverImage": coverImage ${RICH_IMAGE_PROJECTION},
+  hero
+`;
+
+// ── Sanity response types ─────────────────────────────────────────────
+
 type SanityProject = {
-	hero: string;
 	title: string;
 	description: string;
 	year: number | string;
 	displayOrder?: number;
+	featured?: boolean;
+	slug: string;
+	medium: string;
 	role?: string;
 	timeline?: string;
 	context?: string;
-	slug: string;
-	repo: string;
-	liveUrl?: string;
-	medium: string;
+	technologies?: string[];
 	tags?: string[];
 	colors?: string[];
-	technologies?: string[];
-	body?: string;
 	published?: boolean;
+	coverImage?: ResolvedImage;
+	links?: ResolvedLink[];
+	overview?: string;
+	problem?: string;
+	approach?: string;
+	statistics?: ResolvedMetric[];
+	gallery?: ResolvedGalleryItem[];
+	structuredBody?: PortableTextBody;
+	seo?: ResolvedSeo;
+	// Legacy
+	hero?: string;
+	repo?: string;
+	liveUrl?: string;
+	body?: string;
 };
 
+// ── Application model ─────────────────────────────────────────────────
+
 export interface Project {
-	hero: string;
 	title: string;
 	description: string;
-	medium: string;
-	tags: string[];
-	colors: string[];
 	year: string;
-	slug: string;
-	content: string;
-	technologies: {
-		label: string;
-	}[];
-	repo: string;
-	liveUrl?: string;
 	displayOrder?: number;
+	featured: boolean;
+	slug: string;
+	medium: string;
 	role?: string;
 	timeline?: string;
 	context?: string;
+	technologies: { label: string }[];
+	tags: string[];
+	colors: string[];
+	coverImage?: ResolvedImage;
+	links: ResolvedLink[];
+	overview?: string;
+	problem?: string;
+	approach?: string;
+	statistics: ResolvedMetric[];
+	gallery: ResolvedGalleryItem[];
+	structuredBody?: PortableTextBody;
+	seo?: ResolvedSeo;
+	// Legacy — available until migration completes
+	hero: string;
+	repo: string;
+	liveUrl?: string;
+	content: string;
 }
+
+// ── Normalizer ────────────────────────────────────────────────────────
 
 function normalizeProject(project: SanityProject): Project {
 	return {
-		hero: project.hero,
 		title: project.title,
 		description: project.description,
-		medium: project.medium,
-		tags: Array.isArray(project.tags) ? project.tags : [],
-		colors: Array.isArray(project.colors) ? project.colors : [],
 		year: String(project.year),
-		slug: project.slug,
-		content: project.body ?? '',
-		technologies: Array.isArray(project.technologies)
-			? project.technologies.map((technology) => ({ label: technology }))
-			: [],
-		repo: project.repo,
-		liveUrl: project.liveUrl,
 		displayOrder: project.displayOrder,
+		featured: project.featured ?? false,
+		slug: project.slug,
+		medium: project.medium,
 		role: project.role,
 		timeline: project.timeline,
-		context: project.context
+		context: project.context,
+		technologies: Array.isArray(project.technologies)
+			? project.technologies.map((t) => ({ label: t }))
+			: [],
+		tags: Array.isArray(project.tags) ? project.tags : [],
+		colors: Array.isArray(project.colors) ? project.colors : [],
+		coverImage: project.coverImage,
+		links: Array.isArray(project.links) ? project.links : [],
+		overview: project.overview,
+		problem: project.problem,
+		approach: project.approach,
+		statistics: Array.isArray(project.statistics) ? project.statistics : [],
+		gallery: Array.isArray(project.gallery) ? project.gallery : [],
+		structuredBody: project.structuredBody,
+		seo: project.seo,
+		// Legacy
+		hero: project.coverImage?.url ?? project.hero ?? '',
+		repo: project.repo ?? '',
+		liveUrl: project.liveUrl,
+		content: project.body ?? ''
 	};
 }
+
+// ── Queries ───────────────────────────────────────────────────────────
 
 export const getProjects = async (): Promise<Project[]> => {
 	const projects = await fetchSanityQuery<SanityProject[]>(
@@ -99,24 +173,40 @@ export async function getProject(slug: string): Promise<Project | undefined> {
 	return project ? normalizeProject(project) : undefined;
 }
 
-const NEXT_PROJECT_FIELDS = `title, "slug": slug.current, hero, colors`;
+export interface NextProject {
+	title: string;
+	slug: string;
+	hero: string;
+	colors?: string[];
+	coverImage?: ResolvedImage;
+}
 
-export async function getNextProject(displayOrder: number | undefined, slug: string) {
+export async function getNextProject(
+	displayOrder: number | undefined,
+	slug: string
+): Promise<NextProject | undefined> {
 	const order = displayOrder ?? -1;
 	const result = await fetchSanityQuery<SanityProject | null>(
 		`*[_type == "project" && published != false && slug.current != $slug && displayOrder > $order] | order(displayOrder asc, year desc)[0]{ ${NEXT_PROJECT_FIELDS} }`,
 		{ slug, order }
 	);
 
-	if (result)
-		return { title: result.title, slug: result.slug, hero: result.hero, colors: result.colors };
+	if (result) return normalizeNextProject(result);
 
 	const wrap = await fetchSanityQuery<SanityProject | null>(
 		`*[_type == "project" && published != false && slug.current != $slug] | order(displayOrder asc, year desc)[0]{ ${NEXT_PROJECT_FIELDS} }`,
 		{ slug }
 	);
 
-	return wrap
-		? { title: wrap.title, slug: wrap.slug, hero: wrap.hero, colors: wrap.colors }
-		: undefined;
+	return wrap ? normalizeNextProject(wrap) : undefined;
+}
+
+function normalizeNextProject(p: SanityProject): NextProject {
+	return {
+		title: p.title,
+		slug: p.slug,
+		hero: p.coverImage?.url ?? p.hero ?? '',
+		colors: Array.isArray(p.colors) ? p.colors : [],
+		coverImage: p.coverImage
+	};
 }

--- a/src/lib/sanity-types.ts
+++ b/src/lib/sanity-types.ts
@@ -1,0 +1,85 @@
+// ── Reusable GROQ projection fragments ────────────────────────────────
+
+/** Resolves a richImage to url, dimensions, alt, caption, and crop/hotspot */
+export const RICH_IMAGE_PROJECTION = `{
+  alt,
+  caption,
+  "url": asset->url,
+  "width": asset->metadata.dimensions.width,
+  "height": asset->metadata.dimensions.height,
+  "lqip": asset->metadata.lqip,
+  hotspot,
+  crop
+}`;
+
+/** Resolves a gallery item's nested richImage + layout */
+export const GALLERY_ITEM_PROJECTION = `{
+  layout,
+  "image": image ${RICH_IMAGE_PROJECTION}
+}`;
+
+/** Resolves an SEO object's ogImage */
+export const SEO_PROJECTION = `{
+  title,
+  description,
+  "ogImage": ogImage.asset->url
+}`;
+
+/** Resolves a link object */
+export const LINK_PROJECTION = `{ title, url }`;
+
+/** Resolves an author object's avatar */
+export const AUTHOR_PROJECTION = `{
+  name,
+  "avatar": avatar.asset->url,
+  url
+}`;
+
+// ── Resolved application types ─────────────────────────────────────────
+
+export interface ResolvedImage {
+	alt: string;
+	caption?: string;
+	url: string;
+	width: number;
+	height: number;
+	lqip?: string;
+	hotspot?: { x: number; y: number; width: number; height: number };
+	crop?: { top: number; bottom: number; left: number; right: number };
+}
+
+export interface ResolvedGalleryItem {
+	layout: 'wide' | 'half' | 'third';
+	image: ResolvedImage;
+}
+
+export interface ResolvedSeo {
+	title?: string;
+	description?: string;
+	ogImage?: string;
+}
+
+export interface ResolvedLink {
+	title: string;
+	url: string;
+}
+
+export interface ResolvedAuthor {
+	name: string;
+	avatar?: string;
+	url?: string;
+}
+
+export interface ResolvedMetric {
+	value: string;
+	label: string;
+}
+
+/** JSON-safe value type for TanStack Start serialization compatibility. */
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+/**
+ * Portable Text body — kept as the raw Sanity array.
+ * The Portable Text renderer (PER-21) will consume this directly.
+ */
+export type PortableTextBody = { [key: string]: JsonValue }[];


### PR DESCRIPTION
## What
Introduce a shared types and projections module (`src/lib/sanity-types.ts`) that provides:

- **Reusable GROQ projection fragments** — `RICH_IMAGE_PROJECTION`, `GALLERY_ITEM_PROJECTION`, `SEO_PROJECTION`, `LINK_PROJECTION`, `AUTHOR_PROJECTION` that resolve asset URLs, dimensions, LQIP, hotspot/crop metadata directly in GROQ (no `@sanity/image-url` dependency)
- **Typed application interfaces** — `ResolvedImage`, `ResolvedGalleryItem`, `ResolvedSeo`, `ResolvedLink`, `ResolvedAuthor`, `ResolvedMetric`, `PortableTextBody` with TanStack Start serialization-safe types
- **Updated project data module** — projects now project and normalize `coverImage`, `links[]`, `overview`, `problem`, `approach`, `statistics[]`, `gallery[]`, `structuredBody`, and `seo` alongside legacy fields
- **Updated blog data module** — posts now project and normalize `coverImage`, `author`, `category`, `tags`, `canonicalUrl`, `structuredBody`, and `seo` alongside legacy fields

Legacy fields remain projected for migration safety. `coverImage.url` falls back to legacy `hero`/`cover` paths in normalizers.

## Linear
Closes PER-20

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally