### PR TITLE
feat ✨ : structured blog article body with polished styles (PER-38)

### DIFF
--- a/src/data/blog/index.ts
+++ b/src/data/blog/index.ts
@@ -5,7 +5,12 @@ import type {
 	ResolvedImage,
 	ResolvedSeo
 } from '@/lib/sanity-types';
-import { AUTHOR_PROJECTION, RICH_IMAGE_PROJECTION, SEO_PROJECTION } from '@/lib/sanity-types';
+import {
+	AUTHOR_PROJECTION,
+	RICH_IMAGE_PROJECTION,
+	SEO_PROJECTION,
+	STRUCTURED_BODY_PROJECTION
+} from '@/lib/sanity-types';
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
@@ -30,7 +35,7 @@ const POST_FIELDS = `
   "coverImage": coverImage ${RICH_IMAGE_PROJECTION},
   "author": author ${AUTHOR_PROJECTION},
   canonicalUrl,
-  structuredBody,
+  "structuredBody": structuredBody ${STRUCTURED_BODY_PROJECTION},
   "seo": seo ${SEO_PROJECTION},
   // Legacy fields — still projected until migration completes
   body,

--- a/src/data/projects/index.ts
+++ b/src/data/projects/index.ts
@@ -11,7 +11,8 @@ import {
 	GALLERY_ITEM_PROJECTION,
 	LINK_PROJECTION,
 	RICH_IMAGE_PROJECTION,
-	SEO_PROJECTION
+	SEO_PROJECTION,
+	STRUCTURED_BODY_PROJECTION
 } from '@/lib/sanity-types';
 
 // ── GROQ projections ──────────────────────────────────────────────────
@@ -38,7 +39,7 @@ const PROJECT_FIELDS = `
   approach,
   "statistics": statistics[] { value, label },
   "gallery": gallery[] ${GALLERY_ITEM_PROJECTION},
-  structuredBody,
+  "structuredBody": structuredBody ${STRUCTURED_BODY_PROJECTION},
   "seo": seo ${SEO_PROJECTION},
   // Legacy fields — still projected until migration completes
   hero,

--- a/src/lib/sanity-types.ts
+++ b/src/lib/sanity-types.ts
@@ -35,6 +35,12 @@ export const AUTHOR_PROJECTION = `{
   url
 }`;
 
+/** Resolves a structuredBody array with embedded richImage assets */
+export const STRUCTURED_BODY_PROJECTION = `[]{
+  ...,
+  _type == "richImage" => ${RICH_IMAGE_PROJECTION}
+}`;
+
 // ── Resolved application types ─────────────────────────────────────────
 
 export interface ResolvedImage {

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -5,6 +5,7 @@ import { LuArrowUpRight } from 'react-icons/lu';
 
 import { Cover } from '@/components/pages/blog/cover';
 import { MetaBar } from '@/components/pages/blog/meta-bar';
+import { PortableTextRenderer } from '@/components/portable-text';
 import { Badge } from '@/components/ui/badge';
 import { BASE_URL } from '@/data/main';
 import { createSeoHead } from '@/lib/head';
@@ -29,6 +30,7 @@ export const Route = createFileRoute('/blog/$slug')({
 		createSeoHead({
 			title: `${loaderData?.post?.title ?? 'Not found'} | Blog`,
 			description: loaderData?.post?.description ?? 'The requested blog post could not be located.',
+			image: loaderData?.post?.coverImage?.url,
 			alternates: {
 				canonical: `${BASE_URL}/blog/${params.slug}`
 			}
@@ -110,7 +112,20 @@ function useTrackView(slug: string, initialViews: number) {
 
 function BlogShowRoute() {
 	const { post, postHtml, nextPost } = Route.useLoaderData();
-	const { title, description, slug, cover, category, date, readingTime = 0, keywords = [] } = post;
+	const {
+		title,
+		description,
+		slug,
+		cover,
+		coverImage,
+		category,
+		date,
+		readingTime = 0,
+		keywords = [],
+		tags = [],
+		structuredBody,
+		author
+	} = post;
 	const liveViews = useTrackView(slug, 0);
 	const proseRef = useRef<HTMLDivElement>(null);
 	useCodeBarExtraction(proseRef);
@@ -155,29 +170,27 @@ function BlogShowRoute() {
 				<MetaBar slug={slug} title={title} readingTime={readingTime} views={liveViews} />
 			</header>
 
-			{cover && <Cover src={cover} alt={title} />}
+			{(coverImage?.url || cover) && (
+				<Cover src={coverImage?.url ?? cover ?? ''} alt={coverImage?.alt ?? title} />
+			)}
 
-			<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
-				<div
-					ref={proseRef}
-					className="prose dark:prose-invert"
-					dangerouslySetInnerHTML={{ __html: postHtml }}
-				/>
-
-				{keywords.length > 0 && (
-					<div className="mx-auto mt-2 flex max-w-[680px] flex-wrap gap-2">
-						{keywords.map((tag: string) => (
-							<Badge
-								key={`${slug}-${tag}`}
-								variant="outline"
-								className="cursor-default px-3 py-1 text-[10px]"
-							>
-								{tag}
-							</Badge>
-						))}
+			{structuredBody ? (
+				<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
+					<PortableTextRenderer body={structuredBody} />
+				</div>
+			) : (
+				postHtml && (
+					<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
+						<div
+							ref={proseRef}
+							className="prose dark:prose-invert"
+							dangerouslySetInnerHTML={{ __html: postHtml }}
+						/>
 					</div>
-				)}
-			</div>
+				)
+			)}
+
+			<ArticleFooter slug={slug} tags={tags.length > 0 ? tags : keywords} author={author} />
 
 			{nextPost && (
 				<section className="relative left-1/2 mt-[clamp(80px,12vw,140px)] w-screen -translate-x-1/2 border-t border-border">
@@ -201,6 +214,73 @@ function BlogShowRoute() {
 				</section>
 			)}
 		</article>
+	);
+}
+
+function ArticleFooter({
+	slug,
+	tags,
+	author
+}: {
+	slug: string;
+	tags: string[];
+	author?: { name: string; avatar?: string; url?: string };
+}) {
+	const hasTags = tags.length > 0;
+	const hasAuthor = !!author;
+
+	if (!hasTags && !hasAuthor) return null;
+
+	return (
+		<footer className="mx-auto w-full max-w-4xl px-4 mt-[clamp(48px,7vw,80px)] sm:px-6">
+			{hasTags && (
+				<div className="flex flex-wrap gap-2">
+					{tags.map((tag) => (
+						<Badge
+							key={`${slug}-${tag}`}
+							variant="outline"
+							className="cursor-default px-3 py-1 text-[10px]"
+						>
+							{tag}
+						</Badge>
+					))}
+				</div>
+			)}
+
+			{hasAuthor && (
+				<div
+					className={`flex items-center gap-4 ${hasTags ? 'mt-[36px] border-t border-border pt-[36px]' : ''}`}
+				>
+					{author.avatar && (
+						<img
+							src={author.avatar}
+							alt={author.name}
+							className="size-[52px] rounded-full object-cover"
+							loading="lazy"
+						/>
+					)}
+					<div>
+						<div className="font-mono text-[10px] tracking-[0.08em] uppercase text-muted-foreground">
+							Written by
+						</div>
+						{author.url ? (
+							<a
+								href={author.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="mt-[4px] block font-clash text-[17px] font-medium text-foreground no-underline hover:text-[var(--color-orange-primary)] transition-colors duration-300"
+							>
+								{author.name}
+							</a>
+						) : (
+							<div className="mt-[4px] font-clash text-[17px] font-medium text-foreground">
+								{author.name}
+							</div>
+						)}
+					</div>
+				</div>
+			)}
+		</footer>
 	);
 }
 

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -6,7 +6,6 @@ import { LuArrowUpRight } from 'react-icons/lu';
 import { Cover } from '@/components/pages/blog/cover';
 import { MetaBar } from '@/components/pages/blog/meta-bar';
 import { PortableTextRenderer } from '@/components/portable-text';
-import { Badge } from '@/components/ui/badge';
 import { BASE_URL } from '@/data/main';
 import { createSeoHead } from '@/lib/head';
 import { getPostFn } from '@/server-fns/content';
@@ -22,7 +21,6 @@ export const Route = createFileRoute('/blog/$slug')({
 
 		return {
 			post: postData.post,
-			postHtml: postData.postHtml ?? '',
 			nextPost: postData.nextPost
 		};
 	},
@@ -38,57 +36,6 @@ export const Route = createFileRoute('/blog/$slug')({
 	component: BlogShowRoute,
 	notFoundComponent: BlogPostNotFoundRoute
 });
-
-const DOT_COLORS = ['#ff5f57', '#febc2e', '#28c840'];
-
-function useCodeBarExtraction(ref: React.RefObject<HTMLDivElement | null>) {
-	useEffect(() => {
-		const container = ref.current;
-		if (!container) return;
-
-		for (const pre of container.querySelectorAll('pre')) {
-			if (pre.classList.contains('has-bar')) continue;
-
-			const code = pre.querySelector('code');
-			if (!code) continue;
-
-			const firstLine = code.firstElementChild ?? code.firstChild;
-			if (!firstLine) continue;
-
-			const text = (firstLine.textContent ?? '').trim();
-			if (!text.startsWith('//')) continue;
-
-			const filename = text.replace(/^\/\/\s*/, '');
-			if (!filename) continue;
-
-			if (firstLine.nodeType === Node.TEXT_NODE) {
-				firstLine.textContent = (firstLine.textContent ?? '').replace(/^\/\/.*\n?/, '');
-			} else {
-				const next = firstLine.nextSibling;
-				firstLine.remove();
-				if (next?.nodeType === Node.TEXT_NODE && next.textContent?.startsWith('\n')) {
-					next.textContent = next.textContent.slice(1);
-				}
-			}
-
-			const bar = document.createElement('div');
-			bar.className = 'a-code-bar';
-			for (const c of DOT_COLORS) {
-				const dot = document.createElement('span');
-				dot.className = 'a-code-bar-dot';
-				dot.style.background = c;
-				bar.appendChild(dot);
-			}
-			const name = document.createElement('span');
-			name.className = 'a-code-bar-name';
-			name.textContent = filename;
-			bar.appendChild(name);
-
-			pre.classList.add('has-bar');
-			pre.insertBefore(bar, pre.firstChild);
-		}
-	}, [ref]);
-}
 
 function useTrackView(slug: string, initialViews: number) {
 	const [views, setViews] = useState(initialViews);
@@ -111,24 +58,19 @@ function useTrackView(slug: string, initialViews: number) {
 }
 
 function BlogShowRoute() {
-	const { post, postHtml, nextPost } = Route.useLoaderData();
+	const { post, nextPost } = Route.useLoaderData();
 	const {
 		title,
 		description,
 		slug,
-		cover,
 		coverImage,
 		category,
 		date,
 		readingTime = 0,
-		keywords = [],
-		tags = [],
 		structuredBody,
 		author
 	} = post;
 	const liveViews = useTrackView(slug, 0);
-	const proseRef = useRef<HTMLDivElement>(null);
-	useCodeBarExtraction(proseRef);
 
 	const formattedDate = new Date(date).toLocaleDateString('en-US', {
 		year: 'numeric',
@@ -163,34 +105,22 @@ function BlogShowRoute() {
 					{title}
 				</h1>
 
-				<p className="animate-fade-in-left delay-300 mt-[26px] font-clash text-muted-foreground text-pretty font-normal leading-[1.4] tracking-[-0.01em] text-[clamp(19px,2.4vw,27px)]">
+				<p className="animate-fade-in-left delay-300 mt-[26px] font-clash text-foreground text-pretty font-normal leading-[1.4] tracking-[-0.01em] text-[clamp(19px,2.4vw,27px)]">
 					{description}
 				</p>
 
 				<MetaBar slug={slug} title={title} readingTime={readingTime} views={liveViews} />
 			</header>
 
-			{(coverImage?.url || cover) && (
-				<Cover src={coverImage?.url ?? cover ?? ''} alt={coverImage?.alt ?? title} />
-			)}
+			{coverImage?.url && <Cover src={coverImage.url} alt={coverImage.alt ?? title} />}
 
-			{structuredBody ? (
+			{structuredBody && (
 				<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
 					<PortableTextRenderer body={structuredBody} />
 				</div>
-			) : (
-				postHtml && (
-					<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
-						<div
-							ref={proseRef}
-							className="prose dark:prose-invert"
-							dangerouslySetInnerHTML={{ __html: postHtml }}
-						/>
-					</div>
-				)
 			)}
 
-			<ArticleFooter slug={slug} tags={tags.length > 0 ? tags : keywords} author={author} />
+			<ArticleFooter author={author} />
 
 			{nextPost && (
 				<section className="relative left-1/2 mt-[clamp(80px,12vw,140px)] w-screen -translate-x-1/2 border-t border-border">
@@ -217,69 +147,40 @@ function BlogShowRoute() {
 	);
 }
 
-function ArticleFooter({
-	slug,
-	tags,
-	author
-}: {
-	slug: string;
-	tags: string[];
-	author?: { name: string; avatar?: string; url?: string };
-}) {
-	const hasTags = tags.length > 0;
-	const hasAuthor = !!author;
-
-	if (!hasTags && !hasAuthor) return null;
+function ArticleFooter({ author }: { author?: { name: string; avatar?: string; url?: string } }) {
+	if (!author) return null;
 
 	return (
 		<footer className="mx-auto w-full max-w-4xl px-4 mt-[clamp(48px,7vw,80px)] sm:px-6">
-			{hasTags && (
-				<div className="flex flex-wrap gap-2">
-					{tags.map((tag) => (
-						<Badge
-							key={`${slug}-${tag}`}
-							variant="outline"
-							className="cursor-default px-3 py-1 text-[10px]"
-						>
-							{tag}
-						</Badge>
-					))}
-				</div>
-			)}
-
-			{hasAuthor && (
-				<div
-					className={`flex items-center gap-4 ${hasTags ? 'mt-[36px] border-t border-border pt-[36px]' : ''}`}
-				>
-					{author.avatar && (
-						<img
-							src={author.avatar}
-							alt={author.name}
-							className="size-[52px] rounded-full object-cover"
-							loading="lazy"
-						/>
-					)}
-					<div>
-						<div className="font-mono text-[10px] tracking-[0.08em] uppercase text-muted-foreground">
-							Written by
-						</div>
-						{author.url ? (
-							<a
-								href={author.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="mt-[4px] block font-clash text-[17px] font-medium text-foreground no-underline hover:text-[var(--color-orange-primary)] transition-colors duration-300"
-							>
-								{author.name}
-							</a>
-						) : (
-							<div className="mt-[4px] font-clash text-[17px] font-medium text-foreground">
-								{author.name}
-							</div>
-						)}
+			<div className="flex items-center gap-4">
+				{author.avatar && (
+					<img
+						src={author.avatar}
+						alt={author.name}
+						className="size-[52px] rounded-full object-cover"
+						loading="lazy"
+					/>
+				)}
+				<div>
+					<div className="font-mono text-[10px] tracking-[0.08em] uppercase text-muted-foreground">
+						Written by
 					</div>
+					{author.url ? (
+						<a
+							href={author.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="mt-[4px] block font-clash text-[17px] font-medium text-foreground no-underline hover:text-[var(--color-orange-primary)] transition-colors duration-300"
+						>
+							{author.name}
+						</a>
+					) : (
+						<div className="mt-[4px] font-clash text-[17px] font-medium text-foreground">
+							{author.name}
+						</div>
+					)}
 				</div>
-			)}
+			</div>
 		</footer>
 	);
 }

--- a/src/server-fns/content.ts
+++ b/src/server-fns/content.ts
@@ -25,22 +25,19 @@ export const getPostFn = createServerFn({ method: 'GET' })
 	.inputValidator(slugSchema)
 	.handler(async ({ data }) => {
 		try {
-			const [{ getPost, getNextPost }, { renderMdxToHtml }, { highlightCodeBlocks }] =
-				await Promise.all([
-					import('@/data/blog'),
-					import('@/server/mdx'),
-					import('@/server/highlight')
-				]);
+			const [{ getPost, getNextPost }, { highlightCodeBlocks }] = await Promise.all([
+				import('@/data/blog'),
+				import('@/server/highlight')
+			]);
 			const post = await getPost(data.slug);
-			const [postHtml, nextPost, highlightedBody] = await Promise.all([
-				post?.body ? renderMdxToHtml(post.body) : undefined,
+			const [nextPost, highlightedBody] = await Promise.all([
 				post?.date ? getNextPost(post.date, data.slug) : undefined,
 				post?.structuredBody ? highlightCodeBlocks(post.structuredBody) : undefined
 			]);
 			const processedPost =
 				post && highlightedBody ? { ...post, structuredBody: highlightedBody } : post;
 
-			return { post: processedPost, postHtml, nextPost };
+			return { post: processedPost, nextPost };
 		} catch (error) {
 			console.error('Failed to load blog post', error);
 			return {};

--- a/src/styles/blog/index.css
+++ b/src/styles/blog/index.css
@@ -4,12 +4,6 @@
 	margin-top: clamp(48px, 7vw, 76px);
 }
 
-.a-body > * {
-	max-width: 680px;
-	margin-left: auto;
-	margin-right: auto;
-}
-
 .a-body > .prose {
 	max-width: 680px;
 	margin-left: auto;
@@ -33,7 +27,7 @@
 }
 
 .a-body h2 {
-	@apply font-clash text-foreground max-w-[680px] mx-auto;
+	@apply font-clash text-foreground;
 	font-weight: 600;
 	font-size: clamp(26px, 3.4vw, 38px);
 	letter-spacing: -0.02em;
@@ -42,18 +36,23 @@
 }
 
 .a-body h3 {
-	@apply font-clash text-foreground max-w-[680px] mx-auto;
+	@apply font-clash text-foreground;
 	font-weight: 500;
 	font-size: clamp(20px, 2.6vw, 26px);
 	letter-spacing: -0.015em;
 	margin: 40px auto 14px;
 }
 
+.a-body h4 {
+	@apply font-clash text-foreground;
+	font-weight: 500;
+	font-size: clamp(17px, 2.2vw, 21px);
+	letter-spacing: -0.01em;
+	margin: 32px auto 12px;
+}
+
 .a-body ul,
 .a-body ol {
-	max-width: 680px;
-	margin-left: auto;
-	margin-right: auto;
 	@apply font-mono text-foreground mb-6;
 	font-size: 15px;
 	line-height: 1.8;
@@ -91,7 +90,6 @@
 
 .a-body .a-pullquote,
 blockquote {
-	max-width: 680px;
 	margin: 48px auto;
 	padding: 6px 0 6px 26px;
 	border-left: 3px solid var(--color-orange-primary);
@@ -116,13 +114,14 @@ blockquote cite {
 
 .a-body figure,
 .a-figure {
-	max-width: 880px;
-	margin: 44px auto;
+	max-width: none;
+	margin: 44px -20px;
 }
 
 .a-body figure .frame,
 .a-figure-frame {
-	@apply rounded-4xl border border-border overflow-hidden;
+	@apply border border-border overflow-hidden;
+	border-radius: 14px;
 	box-shadow: var(--shadow-card);
 	background: var(--muted);
 }
@@ -142,7 +141,6 @@ blockquote cite {
 
 .a-body hr,
 .a-rule {
-	max-width: 680px;
 	height: 1px;
 	background: var(--border);
 	border: none;
@@ -237,8 +235,12 @@ blockquote cite {
 	margin: 0;
 }
 
-.a-body .a-inline-code {
-	@apply font-mono text-[13px] rounded-md px-1.5 py-0.5;
-	background: var(--muted);
+.a-body .a-inline-code,
+.a-body :not(pre) > code {
+	@apply font-mono rounded-md;
+	font-size: 0.85em;
+	padding: 2px 7px;
+	background: hsl(var(--muted));
 	color: var(--color-orange-primary);
+	border: 1px solid hsl(var(--border));
 }


### PR DESCRIPTION
## What
- Remove legacy MDX rendering fallback (`dangerouslySetInnerHTML`, `renderMdxToHtml`, `useCodeBarExtraction`) from the blog detail page
- Resolve `richImage` asset references in `structuredBody` GROQ projections (blog + projects) so embedded images render correctly
- Extract shared `STRUCTURED_BODY_PROJECTION` constant to eliminate duplication between blog and project data modules
- Polish blog article styles: h4 support, inline code pill styling, image/code block border-radius consistency (14px), full-width body, description color fix

## Linear
Closes PER-38

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally