### PR TITLE
feat ✨ : align markdown responses with structured Sanity content (PER-47)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.2",
+		"@portabletext/markdown": "^1.4.1",
 		"@portabletext/react": "^6.2.0",
 		"@radix-ui/react-avatar": "^1.0.4",
 		"@radix-ui/react-dialog": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.4.0(react-hook-form@7.77.0(react@19.2.7))
+      '@portabletext/markdown':
+        specifier: ^1.4.1
+        version: 1.4.1
       '@portabletext/react':
         specifier: ^6.2.0
         version: 6.2.0(react@19.2.7)
@@ -1969,6 +1972,10 @@ packages:
     resolution: {integrity: sha512-RRYqyK+c5Hm7nzrEkTMiSoHUybU9KefGIN6WxS16L+ki6ehYsPzyySXYxRN3lZL4/ti0qq2icI2S/NRVfCLc1Q==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
+  '@portabletext/markdown@1.4.1':
+    resolution: {integrity: sha512-MulxTDXRfy8fV0Hzdt6jyjs3jKGQ69b6cOlVLpbjeZUJNUHF84wQUvqqn5Qrqzo1cz9OB0JSYd0s5hWeHRR3gQ==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
   '@portabletext/patches@2.0.4':
     resolution: {integrity: sha512-dz2tR921LMvz3tAlfAB5ehJhztGCERFs0j5jEha2Vkq9UAs9iuCxNGlf7C3d2f9pGGBpxOF4WBZgpZNjB84vrQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
@@ -2027,6 +2034,10 @@ packages:
 
   '@portabletext/schema@2.2.0':
     resolution: {integrity: sha512-Dun3sZv+Dp+qF9SSbxldQ+mpn7O7nqGVjq/5DFxFARGRoGlnNHmb9tXS/NV9pqlFZ5+d1GAgnDkMLy4qyU1JZw==}
+    engines: {node: '>=20.19 <22 || >=22.12'}
+
+  '@portabletext/schema@2.2.1':
+    resolution: {integrity: sha512-sreO5HzSc+PDMiYFv4lyh+zpSLp3CFPkyW3gQA2PJ3RQ05pHL7Nbdoopn4B1RvgBPsb1EnmtsUTNcj3VtTLhiA==}
     engines: {node: '>=20.19 <22 || >=22.12'}
 
   '@portabletext/to-html@5.0.2':
@@ -6880,7 +6891,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7605,7 +7616,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8594,6 +8605,13 @@ snapshots:
       '@portabletext/toolkit': 5.0.2
       markdown-it: 14.2.0
 
+  '@portabletext/markdown@1.4.1':
+    dependencies:
+      '@mdit/plugin-alert': 0.23.2(markdown-it@14.2.0)
+      '@portabletext/schema': 2.2.1
+      '@portabletext/toolkit': 5.0.2
+      markdown-it: 14.2.0
+
   '@portabletext/patches@2.0.4':
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
@@ -8660,6 +8678,8 @@ snapshots:
       - supports-color
 
   '@portabletext/schema@2.2.0': {}
+
+  '@portabletext/schema@2.2.1': {}
 
   '@portabletext/to-html@5.0.2':
     dependencies:
@@ -10829,10 +10849,6 @@ snapshots:
   db0@0.3.4: {}
 
   debounce@1.2.1: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3(supports-color@8.1.1):
     dependencies:

--- a/server/agent-ready.ts
+++ b/server/agent-ready.ts
@@ -1,3 +1,4 @@
+import { portableTextToMarkdown } from '@/components/portable-text/to-markdown';
 import { getPost, getPosts } from '@/data/blog';
 import { BASE_URL, data } from '@/data/main';
 import { getProject, getProjects } from '@/data/projects';
@@ -273,15 +274,24 @@ export async function getMarkdownDocument(pathname: string): Promise<string | un
 		const post = await getPost(slug);
 		if (!post) return undefined;
 
+		const bodyText = post.structuredBody
+			? portableTextToMarkdown(post.structuredBody)
+			: post.body
+				? post.body
+				: undefined;
+
 		return [
 			markdownFrontmatter(post.title, normalizedPath, post.description),
 			`# ${post.title}`,
 			'',
 			`- Published: ${post.date}`,
-			post.external_link ? `- Canonical source: ${post.external_link}` : undefined,
-			post.keywords.length > 0 ? `- Keywords: ${post.keywords.join(', ')}` : undefined,
+			post.category ? `- Category: ${post.category}` : undefined,
+			post.readingTime ? `- Reading time: ${post.readingTime} min` : undefined,
+			post.canonicalUrl ? `- Canonical source: ${post.canonicalUrl}` : undefined,
+			post.tags.length > 0 ? `- Tags: ${post.tags.join(', ')}` : undefined,
+			post.author ? `- Author: ${post.author.name}` : undefined,
 			'',
-			post.body
+			bodyText
 		]
 			.filter((part): part is string => Boolean(part))
 			.join('\n');
@@ -295,20 +305,35 @@ export async function getMarkdownDocument(pathname: string): Promise<string | un
 			return undefined;
 		}
 
+		const linkLines = project.links.map((link) => `- [${link.title}](${link.url})`);
+		const caseSections = (
+			[
+				['Overview', project.overview],
+				['Problem', project.problem],
+				['Approach', project.approach]
+			] as const
+		)
+			.filter(([, text]) => Boolean(text))
+			.map(([heading, text]) => `## ${heading}\n\n${text}`)
+			.join('\n\n');
+		const bodyText = project.structuredBody
+			? portableTextToMarkdown(project.structuredBody)
+			: caseSections || undefined;
+
 		return [
 			markdownFrontmatter(project.title, normalizedPath, project.description),
 			`# ${project.title}`,
 			'',
+			`- Medium: ${project.medium}`,
 			`- Year: ${project.year}`,
-			project.liveUrl ? `- Live URL: ${project.liveUrl}` : undefined,
-			project.repo
-				? `- Repository: https://github.com/mariadriana-deemaze/${project.repo}`
-				: undefined,
+			project.role ? `- Role: ${project.role}` : undefined,
+			project.timeline ? `- Timeline: ${project.timeline}` : undefined,
 			project.technologies.length > 0
-				? `- Technologies: ${project.technologies.map((technology) => technology.label).join(', ')}`
+				? `- Technologies: ${project.technologies.map((t) => t.label).join(', ')}`
 				: undefined,
+			linkLines.length > 0 ? ['', '## Links', '', ...linkLines].join('\n') : undefined,
 			'',
-			project.content
+			bodyText
 		]
 			.filter((part): part is string => Boolean(part))
 			.join('\n');

--- a/src/components/portable-text/to-markdown.ts
+++ b/src/components/portable-text/to-markdown.ts
@@ -1,0 +1,28 @@
+import { portableTextToMarkdown as toMarkdown } from '@portabletext/markdown';
+
+import type { PortableTextBody } from '@/lib/sanity-types';
+
+function str(val: unknown): string {
+	return typeof val === 'string' ? val : '';
+}
+
+export function portableTextToMarkdown(body: PortableTextBody): string {
+	return toMarkdown(body as Array<{ _type: string; [key: string]: unknown }>, {
+		types: {
+			code: ({ value }) => {
+				const filename = str(value.filename);
+				return `\`\`\`${str(value.language)}${filename ? ` ${filename}` : ''}\n${str(value.code)}\n\`\`\``;
+			},
+			richImage: ({ value }) => {
+				const url = str(value.url);
+				if (!url) return '';
+				const caption = str(value.caption);
+				return `![${str(value.alt)}](${url})${caption ? `\n*${caption}*` : ''}`;
+			},
+			pullQuote: ({ value }) => {
+				const text = str(value.text);
+				return text ? `> ${text}` : '';
+			}
+		}
+	});
+}


### PR DESCRIPTION
## What
Rewrites the `Accept: text/markdown` middleware responses in `agent-ready.ts` to use structured Sanity fields instead of legacy flat fields, and replaces the custom Portable Text → Markdown converter with `@portabletext/markdown`.

- Blog post markdown now surfaces `category`, `readingTime`, `canonicalUrl`, `tags`, and `author` metadata; body renders from `structuredBody` via the library
- Project markdown now surfaces `medium`, `role`, `timeline`, and `links[]` metadata; body renders from `structuredBody` with full heading/list/image hierarchy
- Added `@portabletext/markdown` as a direct dependency with custom type renderers for `code` (with filename), `richImage`, and `pullQuote`

## Linear
Closes PER-47

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally