### PR TITLE
feat ✨ : complete blog SEO metadata, canonical URLs, and styled 404 (PER-43)

### DIFF
--- a/server/types.ts
+++ b/server/types.ts
@@ -2,6 +2,8 @@ export interface Seo {
 	title: string;
 	description: string;
 	image?: string;
+	url?: string;
+	type?: 'website' | 'article';
 	alternates?: {
 		canonical?: string;
 	};

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -22,11 +22,11 @@ export interface LayoutProps {
 
 export default function Layout({ children, commandLinks = [] }: LayoutProps): ReactNode {
 	return (
-		<div className="max-w-full overflow-y-scroll overflow-x-clip no-scrollbar antialiased lg:mx-auto">
+		<div className="flex min-h-svh flex-col max-w-full overflow-y-scroll overflow-x-clip no-scrollbar antialiased lg:mx-auto">
 			<GoogleAnalytics />
 			<Navbar />
 			<ProgressIndicator />
-			<main className="container relative mx-auto mt-28 print:p-12 no-scrollbar">
+			<main className="container relative mx-auto mt-28 flex flex-1 flex-col print:p-12 no-scrollbar">
 				<BGGrid>{children}</BGGrid>
 				<CommandMenu links={commandLinks} />
 			</main>

--- a/src/components/ui/not-found-page.tsx
+++ b/src/components/ui/not-found-page.tsx
@@ -1,0 +1,26 @@
+import { Link } from '@tanstack/react-router';
+
+interface NotFoundPageProps {
+	title: string;
+	description: string;
+	backTo: string;
+	backLabel: string;
+}
+
+export function NotFoundPage({ title, description, backTo, backLabel }: NotFoundPageProps) {
+	return (
+		<div className="grid flex-1 place-content-center text-center">
+			<h1 className="m-0 font-clash font-medium text-[clamp(40px,6vw,72px)] leading-[0.95] tracking-[-0.03em] text-foreground">
+				{title}
+			</h1>
+			<p className="mt-6 font-mono text-sm text-muted-foreground">{description}</p>
+			<Link
+				to={backTo}
+				className="mt-8 inline-flex items-center justify-center gap-2 font-mono text-sm text-[var(--color-orange-primary)] no-underline hover:gap-3 transition-[gap] duration-300"
+			>
+				<span>←</span>
+				<span>{backLabel}</span>
+			</Link>
+		</div>
+	);
+}

--- a/src/data/routes/blog/index.ts
+++ b/src/data/routes/blog/index.ts
@@ -3,12 +3,12 @@ import type { Seo } from '@/server/types';
 import { ROUTES } from '@/utils/routes';
 
 export function SeoMetadata(): Seo {
+	const url = `${BASE_URL}${ROUTES.blog}`;
 	return {
 		title: `${data.name} | ${data.role} :: Blog`,
 		description:
 			"Explore Maria Adriana's insights on Full Stack Development, with in-depth articles on problem-solving strategies, architecture decisions, performance optimization, and modern web technologies.",
-		alternates: {
-			canonical: `${BASE_URL}${ROUTES.blog}`
-		}
+		url,
+		alternates: { canonical: url }
 	};
 }

--- a/src/data/routes/index.ts
+++ b/src/data/routes/index.ts
@@ -3,12 +3,12 @@ import type { Seo } from '@/server/types';
 import { ROUTES } from '@/utils/routes';
 
 export function SeoMetadata(): Seo {
+	const url = `${BASE_URL}${ROUTES.home}`;
 	return {
 		title: `${data.name} | ${data.role}`,
 		description:
 			'Maria Adriana is a full stack developer based in Portugal, specializing in modern web technologies including Node.js, NestJS, Next.js, TypeScript, and React. Passionate about building scalable, maintainable, and high-performance applications.',
-		alternates: {
-			canonical: `${BASE_URL}${ROUTES.home}`
-		}
+		url,
+		alternates: { canonical: url }
 	};
 }

--- a/src/data/routes/projects/index.ts
+++ b/src/data/routes/projects/index.ts
@@ -3,12 +3,12 @@ import type { Seo } from '@/server/types';
 import { ROUTES } from '@/utils/routes';
 
 export function SeoMetadata(): Seo {
+	const url = `${BASE_URL}${ROUTES.projects}`;
 	return {
 		title: `${data.name} | ${data.role} :: Projects`,
 		description:
 			"Explore Maria Adriana's full stack development projects, featuring work with Node.js, NestJS, Next.js, TypeScript, Go and React. Discover scalable solutions, clean architecture, and modern web applications.",
-		alternates: {
-			canonical: `${BASE_URL}${ROUTES.projects}`
-		}
+		url,
+		alternates: { canonical: url }
 	};
 }

--- a/src/lib/head.ts
+++ b/src/lib/head.ts
@@ -5,8 +5,13 @@ export function createSeoHead(seo: Seo) {
 		{ title: seo.title },
 		{ name: 'description', content: seo.description },
 		{ property: 'og:title', content: seo.title },
-		{ property: 'og:description', content: seo.description }
+		{ property: 'og:description', content: seo.description },
+		{ property: 'og:type', content: seo.type ?? 'website' }
 	];
+
+	if (seo.url) {
+		meta.push({ property: 'og:url', content: seo.url });
+	}
 
 	if (seo.image) {
 		meta.push(

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,12 +1,13 @@
-import { createRootRoute, HeadContent, Link, Scripts } from '@tanstack/react-router';
+import { createRootRoute, HeadContent, Scripts } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 
 import { AppLoaderDismiss, AppLoaderShell } from '@/components/app-loader';
 import Layout from '@/components/layout';
-import { Button } from '@/components/ui/button';
+import { NotFoundPage } from '@/components/ui/not-found-page';
 import { Toaster } from '@/components/ui/sonner';
 import { WebMcpRegistration } from '@/components/webmcp';
 import { getCommandLinksFn } from '@/server-fns/content';
+import { ROUTES } from '@/utils/routes';
 import { getThemeInitScript } from '@/utils/theme';
 
 export const Route = createRootRoute({
@@ -59,15 +60,11 @@ function RootDocument({ children }: { children: ReactNode }) {
 
 function NotFoundRoute() {
 	return (
-		<div className="mx-auto text-center max-w-[450px] mt-10 flex flex-col items-center justify-center">
-			<h2 className="text-fade-grad font-clash text-4xl font-semibold">Not found</h2>
-			<p className="mt-4 text-pretty font-mono text-sm text-foreground">
-				Whatever you were looking for, is simply not here. <br />
-				<i>Have you tried looking under the bed?</i>
-			</p>
-			<Button variant="outline" size="lg" className="mt-10" asChild>
-				<Link to="/">Feeling lucky</Link>
-			</Button>
-		</div>
+		<NotFoundPage
+			title="Page not found"
+			description="Whatever you were looking for, is simply not here."
+			backTo={ROUTES.home}
+			backLabel="Back to home"
+		/>
 	);
 }

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -6,10 +6,11 @@ import { LuArrowUpRight } from 'react-icons/lu';
 import { Cover } from '@/components/pages/blog/cover';
 import { MetaBar } from '@/components/pages/blog/meta-bar';
 import { PortableTextRenderer } from '@/components/portable-text';
+import { NotFoundPage } from '@/components/ui/not-found-page';
 import { BASE_URL } from '@/data/main';
 import { createSeoHead } from '@/lib/head';
 import { getPostFn } from '@/server-fns/content';
-import { ROUTES } from '@/utils/routes';
+import { ROUTES, toBlogSlug } from '@/utils/routes';
 
 export const Route = createFileRoute('/blog/$slug')({
 	loader: async ({ params }) => {
@@ -27,14 +28,15 @@ export const Route = createFileRoute('/blog/$slug')({
 	head: ({ loaderData, params }) => {
 		const post = loaderData?.post;
 		const seo = post?.seo;
+		const canonical = post?.canonicalUrl ?? `${BASE_URL}${toBlogSlug(params.slug)}`;
 		return createSeoHead({
 			title: seo?.title ?? `${post?.title ?? 'Not found'} | Blog`,
 			description:
 				seo?.description ?? post?.description ?? 'The requested blog post could not be located.',
 			image: seo?.ogImage ?? post?.coverImage?.url,
-			alternates: {
-				canonical: `${BASE_URL}/blog/${params.slug}`
-			}
+			url: canonical,
+			type: 'article',
+			alternates: { canonical }
 		});
 	},
 	component: BlogShowRoute,
@@ -191,12 +193,11 @@ function ArticleFooter({ author }: { author?: { name: string; avatar?: string; u
 
 function BlogPostNotFoundRoute() {
 	return (
-		<div className="animate-fade-in-left delay-500">
-			<h1>Post not found</h1>
-			<p>The requested blog post could not be located.</p>
-			<p>
-				<Link to={ROUTES.blog}>Back to blog</Link>
-			</p>
-		</div>
+		<NotFoundPage
+			title="Post not found"
+			description="The requested blog post could not be located."
+			backTo={ROUTES.blog}
+			backLabel="Back to the journal"
+		/>
 	);
 }

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -10,15 +10,16 @@ import { createSeoHead } from '@/lib/head';
 import { ROUTES } from '@/utils/routes';
 
 export const Route = createFileRoute('/contact')({
-	head: () =>
-		createSeoHead({
+	head: () => {
+		const url = `${BASE_URL}${ROUTES.contact}`;
+		return createSeoHead({
 			title: `${data.name} | ${data.role} :: Contact`,
 			description:
 				'Get in touch with Maria Adriana to discuss full stack development projects, consulting work, or collaboration opportunities.',
-			alternates: {
-				canonical: `${BASE_URL}${ROUTES.contact}`
-			}
-		}),
+			url,
+			alternates: { canonical: url }
+		});
+	},
 	component: ContactRoute
 });
 

--- a/src/routes/projects/$slug.tsx
+++ b/src/routes/projects/$slug.tsx
@@ -4,12 +4,13 @@ import { LuArrowUpRight, LuGithub } from 'react-icons/lu';
 
 import { PortableTextRenderer } from '@/components/portable-text';
 import { getStackByName } from '@/components/stacks';
+import { NotFoundPage } from '@/components/ui/not-found-page';
 import { StaggerText } from '@/components/ui/stagger-text';
 import { BASE_URL } from '@/data/main';
 import { createSeoHead } from '@/lib/head';
 import type { ResolvedGalleryItem, ResolvedMetric } from '@/lib/sanity-types';
 import { getProjectFn } from '@/server-fns/content';
-import { ROUTES } from '@/utils/routes';
+import { ROUTES, toProjectsSlug } from '@/utils/routes';
 import { cn } from '@/utils/utils';
 
 export const Route = createFileRoute('/projects/$slug')({
@@ -28,13 +29,14 @@ export const Route = createFileRoute('/projects/$slug')({
 	head: ({ loaderData, params }) => {
 		const project = loaderData?.project;
 		const seo = project?.seo;
+		const url = `${BASE_URL}${toProjectsSlug(params.slug)}`;
 		return createSeoHead({
 			title: seo?.title ?? `${project?.title ?? 'Project'} | Project`,
 			description: seo?.description ?? project?.description ?? 'Project details and information.',
 			image: seo?.ogImage ?? project?.coverImage?.url,
-			alternates: {
-				canonical: `${BASE_URL}/projects/${params.slug}`
-			}
+			url,
+			type: 'article',
+			alternates: { canonical: url }
 		});
 	},
 	component: ProjectItemRoute,
@@ -525,22 +527,11 @@ function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
 
 function ProjectNotFoundRoute() {
 	return (
-		<div className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] pt-[132px] pb-[100px]">
-			<div className="mx-auto max-w-[760px]">
-				<h1 className="m-0 font-clash font-medium text-[clamp(40px,6vw,72px)] leading-[0.95] tracking-[-0.03em] text-foreground">
-					Project not found
-				</h1>
-				<p className="mt-6 font-mono text-sm text-muted-foreground">
-					The requested project could not be located.
-				</p>
-				<Link
-					to={ROUTES.projects}
-					className="mt-8 inline-flex items-center gap-2 font-mono text-sm text-[var(--color-orange-primary)] no-underline hover:gap-3 transition-[gap] duration-300"
-				>
-					<span>←</span>
-					<span>Back to projects</span>
-				</Link>
-			</div>
-		</div>
+		<NotFoundPage
+			title="Project not found"
+			description="The requested project could not be located."
+			backTo={ROUTES.projects}
+			backLabel="Back to projects"
+		/>
 	);
 }


### PR DESCRIPTION
## What
- Add `og:type`, `og:url`, and canonical link tags across all routes (home, blog, projects, contact)
- Blog posts use `canonicalUrl` from Sanity when available, falling back to the default URL
- Blog and project detail pages set `og:type` to `article`
- Extend `Seo` interface with optional `url` and `type` fields
- Align all three 404 pages (root, blog, project) with consistent centered layout and typography
- Make the root layout a flex column so the footer stays at the viewport bottom on short-content pages

## Linear
Closes PER-43

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally