### PR TITLE
feat ✨ : add default OG image fallback and sitemap lastmod dates (PER-48)

### DIFF
--- a/server/site-data.ts
+++ b/server/site-data.ts
@@ -48,17 +48,18 @@ export async function generateCommandLinks(): Promise<CommandLink[]> {
 	return [...internal, ...postLinks, ...projectLinks];
 }
 
+function sitemapEntry(loc: string, lastmod?: string): string {
+	return `  <url>\n    <loc>${loc}</loc>${lastmod ? `\n    <lastmod>${lastmod.split('T')[0]}</lastmod>` : ''}\n  </url>`;
+}
+
 export async function generateSitemapXml(): Promise<string> {
 	const [posts, projects] = await Promise.all([getSafePosts(), getSafeProjects()]);
-	const urls = [
-		...STATIC_ROUTES,
-		...posts.map((post) => toBlogSlug(post.slug)),
-		...projects.map((project) => toProjectsSlug(project.slug))
-	];
 
-	const xmlNodes = urls
-		.map((url) => `  <url>\n    <loc>${BASE_URL}${url}</loc>\n  </url>`)
-		.join('\n');
+	const xmlNodes = [
+		...STATIC_ROUTES.map((route) => sitemapEntry(`${BASE_URL}${route}`)),
+		...posts.map((post) => sitemapEntry(`${BASE_URL}${toBlogSlug(post.slug)}`, post.date)),
+		...projects.map((project) => sitemapEntry(`${BASE_URL}${toProjectsSlug(project.slug)}`))
+	].join('\n');
 
 	return (
 		`<?xml version="1.0" encoding="UTF-8"?>\n` +

--- a/src/lib/head.ts
+++ b/src/lib/head.ts
@@ -1,30 +1,23 @@
+import { BASE_URL } from '@/data/main';
 import type { Seo } from '@/server/types';
 
+const DEFAULT_OG_IMAGE = `${BASE_URL}/images/og-preview.png`;
+
 export function createSeoHead(seo: Seo) {
-	const meta = [
-		{ title: seo.title },
-		{ name: 'description', content: seo.description },
-		{ property: 'og:title', content: seo.title },
-		{ property: 'og:description', content: seo.description },
-		{ property: 'og:type', content: seo.type ?? 'website' }
-	];
-
-	if (seo.url) {
-		meta.push({ property: 'og:url', content: seo.url });
-	}
-
-	if (seo.image) {
-		meta.push(
-			{ property: 'og:image', content: seo.image },
-			{ name: 'twitter:card', content: 'summary_large_image' },
-			{ name: 'twitter:title', content: seo.title },
-			{ name: 'twitter:description', content: seo.description },
-			{ name: 'twitter:image', content: seo.image }
-		);
-	}
+	const image = seo.image ?? DEFAULT_OG_IMAGE;
 
 	return {
-		meta,
+		meta: [
+			{ title: seo.title },
+			{ name: 'description', content: seo.description },
+			{ property: 'og:title', content: seo.title },
+			{ property: 'og:description', content: seo.description },
+			{ property: 'og:type', content: seo.type ?? 'website' },
+			{ property: 'og:image', content: image },
+			{ name: 'twitter:card', content: 'summary_large_image' },
+			{ name: 'twitter:image', content: image },
+			...(seo.url ? [{ property: 'og:url', content: seo.url }] : [])
+		],
 		links: seo.alternates?.canonical
 			? [{ rel: 'canonical', href: seo.alternates.canonical }]
 			: undefined

--- a/src/routes/sitemap[.]xml.ts
+++ b/src/routes/sitemap[.]xml.ts
@@ -9,7 +9,8 @@ export const Route = createFileRoute('/sitemap.xml')({
 
 				return new Response(xml, {
 					headers: {
-						'Content-Type': 'application/xml; charset=utf-8'
+						'Content-Type': 'application/xml; charset=utf-8',
+						'Cache-Control': 'public, max-age=3600, s-maxage=86400'
 					}
 				});
 			}


### PR DESCRIPTION
## What
- `createSeoHead` now always emits `og:image` and `twitter:image` tags, falling back to `/images/og-preview.png` when no page-specific image is provided — covers home, blog index, projects index, and contact
- Sitemap blog entries now include `<lastmod>` dates derived from post publish dates
- Extracted `sitemapEntry` helper for cleaner XML generation

## Linear
Closes PER-48

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally