### PR TITLE
perf ⚡ : audit a11y, reduced motion, image loading, and layout perf (PER-49)

### DIFF
--- a/src/components/bg-grid.tsx
+++ b/src/components/bg-grid.tsx
@@ -70,6 +70,8 @@ export function BGGrid({ children }: { children?: ReactNode }) {
 					className="absolute -left-10 top-32 w-[300px] h-[600px] opacity-50"
 					style={{ transition: BLOB_TRANSITION }}
 					src="/images/color_grad.webp"
+					width={300}
+					height={600}
 					alt=""
 					aria-hidden="true"
 				/>
@@ -78,6 +80,8 @@ export function BGGrid({ children }: { children?: ReactNode }) {
 					className="absolute -right-10 -top-32 w-[200px] h-[400px] opacity-[0.15]"
 					style={{ transition: BLOB_TRANSITION, transform: 'rotate(180deg)' }}
 					src="/images/color_grad.webp"
+					width={200}
+					height={400}
 					alt=""
 					aria-hidden="true"
 				/>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -158,16 +158,22 @@ export function Navbar() {
 							key={path}
 							to={path}
 							className={cn(
-								'flex items-baseline gap-4 border-b border-border no-underline',
+								'flex items-baseline gap-4 no-underline relative',
 								'font-clash font-medium tracking-[-0.03em]',
 								'text-[clamp(40px,13vw,68px)] leading-[1.04] py-[10px]',
 								'transition-opacity duration-300 ease-out',
+								'after:absolute after:bottom-0 after:left-0 after:h-px after:w-full after:bg-border',
+								'after:origin-left after:transition-[scale] after:duration-500 after:[transition-timing-function:cubic-bezier(0.25,1,0.5,1)] after:[transition-delay:var(--divider-delay)]',
+								menuOpen ? 'after:scale-x-100' : 'after:scale-x-0',
 								isActive(path) ? 'text-[var(--color-orange-primary)]' : 'text-foreground'
 							)}
-							style={{
-								opacity: menuOpen ? 1 : 0,
-								transitionDelay: menuOpen ? `${0.1 + i * 0.05}s` : '0s'
-							}}
+							style={
+								{
+									opacity: menuOpen ? 1 : 0,
+									transitionDelay: menuOpen ? `${0.1 + i * 0.05}s` : '0s',
+									'--divider-delay': menuOpen ? `${0.18 + i * 0.07}s` : '0s'
+								} as React.CSSProperties
+							}
 							onClick={() => setMenuOpen(false)}
 						>
 							<span className="font-mono text-[13px] font-semibold text-[var(--color-orange-primary)] translate-y-[-0.4em]">

--- a/src/components/now-playing.tsx
+++ b/src/components/now-playing.tsx
@@ -65,6 +65,8 @@ export const NowPlaying = () => {
 				{isPlaying && albumImageUrl && (
 					<img
 						src={albumImageUrl}
+						width={42}
+						height={42}
 						className="absolute inset-0 w-full h-full object-cover blur-[8px] scale-[1.2] opacity-40 rounded-[9px] motion-reduce:hidden pointer-events-none"
 						aria-hidden="true"
 					/>
@@ -73,7 +75,12 @@ export const NowPlaying = () => {
 					className={`relative w-[42px] h-[42px] rounded-[9px] grid place-items-center overflow-hidden transition-scale duration-[450ms] [transition-timing-function:var(--ease-out)] group-hover:scale-[1.05] [&_img]:w-full [&_img]:h-full [&_img]:object-cover [&_img]:block [&_svg]:w-[22px] [&_svg]:h-[22px] ${isPlaying ? 'text-white bg-[linear-gradient(140deg,#1ed760,#169c46_55%,#0c6b30)]' : 'text-muted-foreground bg-muted'}`}
 				>
 					{isPlaying && albumImageUrl ? (
-						<img src={albumImageUrl} alt={nowPlaying.data.album || 'Album cover'} />
+						<img
+							src={albumImageUrl}
+							alt={nowPlaying.data.album || 'Album cover'}
+							width={42}
+							height={42}
+						/>
 					) : (
 						<HeadphonesIcon />
 					)}

--- a/src/components/pages/blog/cover.tsx
+++ b/src/components/pages/blog/cover.tsx
@@ -9,6 +9,8 @@ export function Cover({ src, alt }: CoverProps) {
 	const innerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
 		let raf: number;
 
 		const onScroll = () => {
@@ -30,7 +32,13 @@ export function Cover({ src, alt }: CoverProps) {
 	return (
 		<div className="animate-fade-in-left delay-300 relative left-1/2 mt-12 w-screen -translate-x-1/2 overflow-hidden bg-muted h-[clamp(300px,52vh,600px)]">
 			<div className="absolute inset-y-[-10%] inset-x-0 will-change-transform" ref={innerRef}>
-				<img src={src} alt={alt} className="block size-full object-cover" />
+				<img
+					src={src}
+					alt={alt}
+					loading="eager"
+					fetchPriority="high"
+					className="block size-full object-cover"
+				/>
 			</div>
 			<div
 				className="absolute inset-0"

--- a/src/components/pages/home/motto.tsx
+++ b/src/components/pages/home/motto.tsx
@@ -60,17 +60,18 @@ export const AnimatedMottos = ({ data, className }: { data: string[]; className?
 	}, [animateText]);
 
 	useEffect(() => {
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 		const interval = setInterval(switchRole, 5000);
 		return () => clearInterval(interval);
 	}, [switchRole]);
 
 	return (
-		<h6 className="h-5 w-full relative roles-slider font-clash text-lg font-normal">
+		<p className="h-5 w-full relative roles-slider font-clash text-lg font-normal">
 			{data.map((item, index) => (
 				<span className={cn('role-slide', className)} key={`motto_item_${index}`}>
 					{item}
 				</span>
 			))}
-		</h6>
+		</p>
 	);
 };

--- a/src/components/pages/home/section-education.tsx
+++ b/src/components/pages/home/section-education.tsx
@@ -27,6 +27,8 @@ export const SectionEducation = () => {
 									className="w-[26px] h-[26px] object-contain block"
 									src={preview}
 									alt={school}
+									width={26}
+									height={26}
 								/>
 							) : (
 								<span className="font-clash font-semibold text-[17px] text-[var(--color-orange-primary)]">

--- a/src/components/pages/home/section-hero.tsx
+++ b/src/components/pages/home/section-hero.tsx
@@ -14,25 +14,31 @@ export const SectionHero = () => {
 	const shineRef = useRef<HTMLDivElement>(null);
 	const highlightRef = useRef<HTMLDivElement>(null);
 
+	const tiltRaf = useRef(0);
+
 	const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 		const el = avatarRef.current;
 		const border = borderRef.current;
 		const shine = shineRef.current;
 		const highlight = highlightRef.current;
 		if (!el || !border || !shine || !highlight) return;
-		const rect = el.getBoundingClientRect();
-		const x = (e.clientX - rect.left) / rect.width - 0.5;
-		const y = (e.clientY - rect.top) / rect.height - 0.5;
-		el.style.transform = `perspective(500px) rotateY(${x * TILT_MAX}deg) rotateX(${-y * TILT_MAX}deg) scale3d(1.04,1.04,1.04)`;
-		shine.style.transform = `translate(${x * 30}px, ${y * 30}px)`;
-		shine.style.opacity = '0.18';
-		const px = (x + 0.5) * rect.width;
-		const py = (y + 0.5) * rect.height;
-		highlight.style.transform = `translate(${px - 40}px, ${py - 40}px)`;
-		highlight.style.opacity = '0.45';
-		const angle = Math.atan2(y, x) * (180 / Math.PI) - 90;
-		border.style.background = `conic-gradient(from ${angle - 25}deg at 50% 50%, hsl(var(--border)) 0deg, rgba(241,90,36,0.9) 25deg, rgba(251,146,60,0.6) 40deg, hsl(var(--border)) 55deg, hsl(var(--border)) 360deg)`;
+		const { clientX, clientY } = e;
+		if (tiltRaf.current) return;
+		tiltRaf.current = requestAnimationFrame(() => {
+			tiltRaf.current = 0;
+			const rect = el.getBoundingClientRect();
+			const x = (clientX - rect.left) / rect.width - 0.5;
+			const y = (clientY - rect.top) / rect.height - 0.5;
+			el.style.transform = `perspective(500px) rotateY(${x * TILT_MAX}deg) rotateX(${-y * TILT_MAX}deg) scale3d(1.04,1.04,1.04)`;
+			shine.style.transform = `translate(${x * 30}px, ${y * 30}px)`;
+			shine.style.opacity = '0.18';
+			const px = (x + 0.5) * rect.width;
+			const py = (y + 0.5) * rect.height;
+			highlight.style.transform = `translate(${px - 40}px, ${py - 40}px)`;
+			highlight.style.opacity = '0.45';
+			const angle = Math.atan2(y, x) * (180 / Math.PI) - 90;
+			border.style.background = `conic-gradient(from ${angle - 25}deg at 50% 50%, hsl(var(--border)) 0deg, rgba(241,90,36,0.9) 25deg, rgba(251,146,60,0.6) 40deg, hsl(var(--border)) 55deg, hsl(var(--border)) 360deg)`;
+		});
 	};
 
 	const handleMouseLeave = () => {
@@ -132,6 +138,9 @@ export const SectionHero = () => {
 										className="w-full h-full object-cover block"
 										alt={data.name}
 										src="images/avatar.jpeg"
+										width={92}
+										height={92}
+										loading="eager"
 									/>
 									<div
 										ref={shineRef}

--- a/src/components/pages/home/section-work-experience.tsx
+++ b/src/components/pages/home/section-work-experience.tsx
@@ -30,6 +30,8 @@ export const SectionWorkExperience = () => {
 									className="w-[26px] h-[26px] object-contain block"
 									src={preview}
 									alt={company}
+									width={26}
+									height={26}
 								/>
 							)}
 						</div>

--- a/src/components/ui/entry-card.tsx
+++ b/src/components/ui/entry-card.tsx
@@ -27,7 +27,13 @@ export function EntryCardLogo({ src, alt }: { src?: string; alt: string }) {
 	return (
 		<div className="w-11 h-11 rounded-[9px] border border-border bg-background dark:bg-[#0a0908] grid place-items-center overflow-hidden shrink-0 shadow-sm">
 			{src ? (
-				<img src={src} alt={alt} className="w-[26px] h-[26px] object-contain" />
+				<img
+					src={src}
+					alt={alt}
+					width={26}
+					height={26}
+					className="w-[26px] h-[26px] object-contain"
+				/>
 			) : (
 				<span className="font-clash font-semibold text-[17px] text-[var(--color-orange-primary)]">
 					{alt.charAt(0)}

--- a/src/components/ui/section-reveal.tsx
+++ b/src/components/ui/section-reveal.tsx
@@ -18,6 +18,7 @@ export function ScrollFadeReveal({
 	onLoadVisibility = false
 }: ScrollFadeRevealProps) {
 	const ref = useRef<HTMLDivElement>(null);
+	const lenisActive = useRef(false);
 
 	const applyReveal = useCallback(() => {
 		const el = ref.current;
@@ -29,12 +30,16 @@ export function ScrollFadeReveal({
 		el.style.translate = `0 ${(1 - progress) * REVEAL_OFFSET_PX}px`;
 	}, [onLoadVisibility]);
 
-	useLenis(applyReveal);
+	useLenis(() => {
+		lenisActive.current = true;
+		applyReveal();
+	});
 
 	useEffect(() => {
 		if (onLoadVisibility) return;
 		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 		applyReveal();
+		if (lenisActive.current) return;
 		window.addEventListener('scroll', applyReveal, { passive: true });
 		return () => window.removeEventListener('scroll', applyReveal);
 	}, [applyReveal, onLoadVisibility]);

--- a/src/routes/projects/$slug.tsx
+++ b/src/routes/projects/$slug.tsx
@@ -304,6 +304,8 @@ function ProjectItemRoute() {
 							alt={coverImage.alt ?? `${title} project cover`}
 							width={coverImage.width}
 							height={coverImage.height}
+							loading="eager"
+							fetchPriority="high"
 							className="block size-full object-cover"
 							{...(coverImage.lqip
 								? {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -217,8 +217,12 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.hero-scrollcue-bar::after {
-		animation: none;
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
 	}
 }
 
@@ -280,13 +284,13 @@
 @utility nav-bg {
 	background: linear-gradient(
 		to right,
-		transparent,
+		color-mix(in srgb, hsl(var(--background)) 72%, transparent),
 		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 12%,
 		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 88%,
-		transparent
+		color-mix(in srgb, hsl(var(--background)) 72%, transparent)
 	);
-	backdrop-filter: blur(8px) saturate(1.1);
-	-webkit-backdrop-filter: blur(8px) saturate(1.1);
+	backdrop-filter: blur(12px) saturate(1.1);
+	-webkit-backdrop-filter: blur(12px) saturate(1.1);
 }
 
 @utility nav-bg-scrolled {


### PR DESCRIPTION
## What
Broad audit of accessibility, reduced motion, image loading, and layout performance across the portfolio.

- Blanket `prefers-reduced-motion: reduce` CSS guard for all animations/transitions
- RAF-wrapped mousemove handlers to prevent layout thrashing
- Explicit `width`/`height` on all images (avatar, blobs, album covers, logos)
- `loading="eager"` + `fetchPriority="high"` on above-the-fold hero images
- Lenis/native scroll listener deduplication via `lenisActive` ref
- Heading hierarchy fix (`h6` → `p` in motto)
- Navbar `nav-bg` opacity/blur consistency with `nav-bg-scrolled`
- Staggered divider animation on mobile menu reveal

## Linear
Closes PER-49

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally