### PR TITLE
styles 🎨 : visual polish and element parity (PER-54)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,5 +14,5 @@
 		"type": true
 	},
 	"tags": ["-lintignore"],
-	"ignoreFiles": ["./.cz-config.cjs", "./src/data/**"]
+	"ignoreFiles": ["./.cz-config.cjs", "./src/data/**", "./src/components/now-playing.tsx"]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "portfolio-2025",
 	"private": true,
-	"version": "0.0.0",
+	"version": "2.0.0",
 	"license": "UNLICENSED",
 	"type": "module",
 	"packageManager": "pnpm@10.33.2",

--- a/src/components/bg-grid.tsx
+++ b/src/components/bg-grid.tsx
@@ -88,8 +88,8 @@ export function BGGrid({ children }: { children?: ReactNode }) {
 			</div>
 
 			{/* Vertical orange sidelines */}
-			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px left-[max(14px,4vw)] bg-brand opacity-[0.22]" />
-			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px right-[max(14px,4vw)] bg-brand opacity-[0.22]" />
+			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px left-[var(--sideline-inset)] bg-brand opacity-[0.22]" />
+			<div className="fixed top-0 bottom-0 z-0 pointer-events-none w-px right-[var(--sideline-inset)] bg-brand opacity-[0.22]" />
 		</>
 	);
 }

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -59,6 +59,7 @@ interface Props {
 export const CommandMenu = ({ links }: Props) => {
 	const [open, setOpen] = useState(false);
 	const [fabHidden, setFabHidden] = useState(false);
+	const [navMenuOpen, setNavMenuOpen] = useState(false);
 	const navigate = useNavigate();
 
 	const internalLinks = links.filter((link) => link.type === 'internal');
@@ -73,8 +74,15 @@ export const CommandMenu = ({ links }: Props) => {
 				setOpen((prev) => !prev);
 			}
 		};
+		const onNavMenu = (e: Event) => {
+			if (e instanceof CustomEvent) setNavMenuOpen(e.detail.open);
+		};
 		document.addEventListener('keydown', down);
-		return () => document.removeEventListener('keydown', down);
+		window.addEventListener('navmenu', onNavMenu);
+		return () => {
+			document.removeEventListener('keydown', down);
+			window.removeEventListener('navmenu', onNavMenu);
+		};
 	}, []);
 
 	useLenis(({ scroll }) => {
@@ -97,7 +105,7 @@ export const CommandMenu = ({ links }: Props) => {
 					'cursor-pointer',
 					'transition-[translate,opacity,box-shadow,color] duration-[450ms] [transition-timing-function:var(--ease-out)]',
 					'hover:text-foreground hover:-translate-y-[3px] hover:shadow-[0_22px_46px_-14px_rgba(0,0,0,0.42)]',
-					fabHidden
+					fabHidden || navMenuOpen
 						? 'opacity-0 translate-y-[140%] pointer-events-none'
 						: 'opacity-100 translate-y-0'
 				)}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
 	const year = new Date().getFullYear();
 
 	return (
-		<footer className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-16 mb-6 flex items-center justify-between border-t border-border pt-4 font-mono text-xs text-muted-foreground">
+		<footer className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-16 mb-6 flex flex-wrap items-center justify-center sm:justify-between gap-3 border-t border-border pt-4 font-mono text-xs text-muted-foreground">
 			<span>
 				© {year} {data.name} · {data.location}
 			</span>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { LuArrowUpRight } from 'react-icons/lu';
 
 import { LogoMark } from '@/components/logo-ma';
+import { NowPlayingBadge } from '@/components/now-playing-badge';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { StaggerText } from '@/components/ui/stagger-text';
 import { data } from '@/data/main';
@@ -115,6 +116,7 @@ export function Navbar() {
 					</div>
 
 					<div className="flex items-center gap-[7px] shrink-0">
+						<NowPlayingBadge />
 						<ThemeToggle />
 
 						<button

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -82,7 +82,7 @@ export function Navbar() {
 					hidden ? '-translate-y-[130%] opacity-0' : 'translate-y-0 opacity-100'
 				)}
 			>
-				<div className="max-w-[1100px] mx-auto px-6 pb-[9px] flex items-center justify-between gap-[10px]">
+				<div className="max-w-[1100px] mx-auto px-[var(--sideline-inset)] pb-[9px] flex items-center justify-between gap-[10px]">
 					<div className="flex items-center gap-1 min-w-0">
 						<Link
 							to={ROUTES.home}
@@ -118,7 +118,7 @@ export function Navbar() {
 						<ThemeToggle />
 
 						<button
-							className="group sm:hidden relative w-8 h-8 cursor-pointer shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-[8px]"
+							className="group sm:hidden relative w-8 h-8 -mr-[8px] cursor-pointer shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-[8px]"
 							onClick={() => setMenuOpen((m) => !m)}
 							aria-label="Toggle menu"
 							aria-expanded={menuOpen}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,5 +1,7 @@
 import { Link, useRouterState } from '@tanstack/react-router';
+import { useLenis } from 'lenis/react';
 import { useEffect, useRef, useState } from 'react';
+import { LuArrowUpRight } from 'react-icons/lu';
 
 import { LogoMark } from '@/components/logo-ma';
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -31,6 +33,14 @@ export function Navbar() {
 		menuOpenRef.current = menuOpen;
 	}, [menuOpen]);
 
+	const lenis = useLenis();
+
+	useEffect(() => {
+		if (!lenis) return;
+		if (menuOpen) lenis.stop();
+		else lenis.start();
+	}, [menuOpen, lenis]);
+
 	useEffect(() => {
 		let last = window.scrollY;
 		const onScroll = () => {
@@ -52,10 +62,10 @@ export function Navbar() {
 	}, []);
 
 	useEffect(() => {
-		document.body.style.overflow = menuOpen ? 'hidden' : '';
-		return () => {
-			document.body.style.overflow = '';
-		};
+		if (menuOpen) document.documentElement.setAttribute('data-menu-open', '');
+		else document.documentElement.removeAttribute('data-menu-open');
+		window.dispatchEvent(new CustomEvent('navmenu', { detail: { open: menuOpen } }));
+		return () => document.documentElement.removeAttribute('data-menu-open');
 	}, [menuOpen]);
 
 	const isActive = (path: string) =>
@@ -108,7 +118,7 @@ export function Navbar() {
 						<ThemeToggle />
 
 						<button
-							className="sm:hidden bg-card-ghost relative w-8 h-8 rounded-[8px] border border-border cursor-pointer shrink-0 transition-[background] duration-[250ms] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+							className="group sm:hidden relative w-8 h-8 cursor-pointer shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-[8px]"
 							onClick={() => setMenuOpen((m) => !m)}
 							aria-label="Toggle menu"
 							aria-expanded={menuOpen}
@@ -119,7 +129,7 @@ export function Navbar() {
 									'transition-[translate,rotate] duration-[320ms] ease-out',
 									menuOpen
 										? 'translate-x-[-50%] translate-y-[-50%] rotate-45'
-										: 'translate-x-[-50%] translate-y-[calc(-50%_-_4px)]'
+										: 'translate-x-[-50%] translate-y-[calc(-50%_-_4px)] group-hover:translate-y-[calc(-50%_-_2.5px)]'
 								)}
 							/>
 							<span
@@ -128,7 +138,7 @@ export function Navbar() {
 									'transition-[translate,rotate] duration-[320ms] ease-out',
 									menuOpen
 										? 'translate-x-[-50%] translate-y-[-50%] -rotate-45'
-										: 'translate-x-[-50%] translate-y-[calc(-50%_+_4px)]'
+										: 'translate-x-[-50%] translate-y-[calc(-50%_+_4px)] group-hover:translate-y-[calc(-50%_+_2.5px)]'
 								)}
 							/>
 						</button>
@@ -148,7 +158,7 @@ export function Navbar() {
 				)}
 			>
 				<div
-					className="absolute inset-0 overlay-grid opacity-[0.04] pointer-events-none"
+					className="absolute inset-0 overlay-grid opacity-[0.04] pointer-events-none [mask-image:linear-gradient(180deg,white_30%,transparent_75%)]"
 					aria-hidden="true"
 				/>
 
@@ -176,7 +186,14 @@ export function Navbar() {
 							}
 							onClick={() => setMenuOpen(false)}
 						>
-							<span className="font-mono text-[13px] font-semibold text-[var(--color-orange-primary)] translate-y-[-0.4em]">
+							<span
+								className="font-mono text-[13px] font-semibold text-[var(--color-orange-primary)] translate-y-[-0.4em] transition-[opacity,filter] duration-[500ms] [transition-timing-function:var(--ease-out)] motion-reduce:transition-none"
+								style={{
+									opacity: menuOpen ? 1 : 0,
+									filter: menuOpen ? 'blur(0px)' : 'blur(6px)',
+									transitionDelay: menuOpen ? `${0.25 + i * 0.08}s` : '0s'
+								}}
+							>
 								{String(i + 1).padStart(2, '0')}
 							</span>
 							<StaggerText
@@ -186,9 +203,9 @@ export function Navbar() {
 								letterDelay={0.025}
 								className="flex-1"
 							/>
-							<span
+							<LuArrowUpRight
 								className={cn(
-									'font-mono text-[22px]',
+									'w-[22px] h-[22px] shrink-0 self-center',
 									'[transition:opacity_300ms_ease-out,translate_300ms_ease-out,color_300ms_ease-out]',
 									isActive(path) ? 'text-[var(--color-orange-primary)]' : 'text-muted-foreground'
 								)}
@@ -196,33 +213,28 @@ export function Navbar() {
 									opacity: isActive(path) ? 1 : 0,
 									translate: isActive(path) ? 'none' : '-8px 4px'
 								}}
-							>
-								↗
-							</span>
+							/>
 						</Link>
 					))}
 				</nav>
 
-				<div
-					className={cn(
-						'relative flex items-center flex-wrap gap-4 mt-auto pt-8',
-						'transition-opacity duration-500',
-						menuOpen ? 'opacity-100' : 'opacity-0'
-					)}
-				>
-					<span className="flex gap-4 font-mono text-[12px]">
-						{data.contact.social.map((s) => (
-							<a
-								key={s.name}
-								href={s.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								className="lowercase text-foreground no-underline opacity-70 transition-[opacity,color] duration-200 hover:opacity-100 hover:text-[var(--color-orange-primary)]"
-							>
-								{s.name}
-							</a>
-						))}
-					</span>
+				<div className="relative flex items-center flex-wrap gap-4 mt-auto pt-8 font-mono text-[12px]">
+					{data.contact.social.map((s, i) => (
+						<a
+							key={s.name}
+							href={s.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="lowercase text-foreground no-underline opacity-70 transition-[opacity,color] duration-200 hover:opacity-100 hover:text-[var(--color-orange-primary)]"
+						>
+							<StaggerText
+								text={s.name}
+								revealed={menuOpen}
+								baseDelay={0.4 + i * 0.1}
+								letterDelay={0.04}
+							/>
+						</a>
+					))}
 				</div>
 			</div>
 		</>

--- a/src/components/now-playing-badge.tsx
+++ b/src/components/now-playing-badge.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query';
+import { Badge } from '@/components/ui/badge';
+import type { NowPlayingData } from '@/server/routes/api/types/spotify';
+
+const ALBUM_ART_SIZE = 64;
+const BADGE_PADDING_EXPANDED = 12; // px-3 = 12px
+const CONTENT_PADDING = 4; // p-1 = 4px
+
+export const NowPlayingBadge = () => {
+	const { data: nowPlaying } = useQuery<{ data: NowPlayingData }>({
+		queryKey: ['nowPlaying'],
+		queryFn: async () => fetch('/api/spotify/currently-playing').then((r) => r.json()),
+		refetchInterval: 5000
+	});
+
+	return (
+		<div>
+			{nowPlaying?.data.isPlaying ? (
+				<a href={nowPlaying?.data.songUrl} target="_blank" rel="noreferrer" className="group block">
+					<div className="flex items-start">
+						<div className="relative h-6 inline-block max-w-[220px] align-top">
+							<span className="invisible block h-6 px-2 py-0 font-mono text-[11px] font-medium leading-snug truncate">
+								{nowPlaying?.data.title} - {nowPlaying?.data.artist}
+							</span>
+							<Badge
+								variant="outline"
+								className="absolute left-0 top-0 text-card-foreground h-6 w-max max-w-[220px] rounded-[24px] px-2 py-0 sm:left-auto sm:right-0 group-hover:h-24 group-hover:w-[320px] group-hover:max-w-none group-hover:rounded-[10px] group-hover:px-3 group-hover:py-2 group-focus-within:h-24 group-focus-within:w-[320px] group-focus-within:max-w-none group-focus-within:rounded-[10px] group-focus-within:px-3 group-focus-within:py-2 z-10 bg-card-ghost"
+								style={{
+									transition:
+										'width 600ms cubic-bezier(0.22,1,0.36,1), height 600ms cubic-bezier(0.22,1,0.36,1), border-radius 900ms ease-out'
+								}}
+							>
+								{/* Blur glow — positioned to land behind the album art in expanded state */}
+								{nowPlaying?.data.albumImageUrl && (
+									<img
+										src={nowPlaying.data.albumImageUrl}
+										alt=""
+										aria-hidden="true"
+										className="absolute opacity-0 object-cover blur-[8px] scale-[1.12] rounded-[9px] pointer-events-none transition-opacity duration-75 group-hover:opacity-40 group-hover:duration-500 group-focus-within:opacity-40 group-focus-within:duration-500"
+										style={{
+											width: ALBUM_ART_SIZE,
+											height: ALBUM_ART_SIZE,
+											left: BADGE_PADDING_EXPANDED + CONTENT_PADDING,
+											top: BADGE_PADDING_EXPANDED + CONTENT_PADDING
+										}}
+									/>
+								)}
+								<div className="relative flex h-full min-w-0 flex-col justify-center gap-0 overflow-hidden">
+									<div className="flex min-w-0 items-center overflow-hidden max-h-6 opacity-100 transition-[max-height,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:max-h-0 group-hover:opacity-0 group-focus-within:max-h-0 group-focus-within:opacity-0">
+										<span className="min-w-0 flex-1 text-left font-mono text-[11px] font-medium leading-snug truncate">
+											{nowPlaying?.data.title} - {nowPlaying?.data.artist}
+										</span>
+									</div>
+									<div className="overflow-hidden w-0 max-w-0 max-h-0 p-0 opacity-0 transition-[max-height,opacity] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:w-full group-hover:max-w-none group-hover:max-h-24 group-hover:opacity-100 group-hover:p-1 group-focus-within:w-full group-focus-within:max-w-none group-focus-within:max-h-24 group-focus-within:opacity-100 group-focus-within:p-1">
+										<div className="flex items-stretch gap-3">
+											{nowPlaying?.data.albumImageUrl ? (
+												<img
+													src={nowPlaying.data.albumImageUrl}
+													alt={nowPlaying?.data.album || 'Album cover'}
+													className="relative h-16 w-16 shrink-0 rounded-md object-cover"
+													loading="lazy"
+												/>
+											) : null}
+											<div className="flex h-16 min-w-0 flex-col justify-center">
+												<p className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+													Now Playing
+												</p>
+												<p className="font-clash text-[14px] font-semibold leading-snug text-foreground line-clamp-1 mt-[2px]">
+													{nowPlaying?.data.title}
+												</p>
+												<p className="font-mono text-[12px] text-foreground/80 line-clamp-1">
+													{nowPlaying?.data.artist}
+												</p>
+												{nowPlaying?.data.album ? (
+													<p className="font-mono text-[11px] text-muted-foreground line-clamp-1">
+														{nowPlaying?.data.album}
+													</p>
+												) : null}
+											</div>
+										</div>
+									</div>
+								</div>
+							</Badge>
+						</div>
+						<span className="order-first mr-1 ml-0 sm:order-none sm:ml-1 sm:mr-0">
+							<svg className="h-4 w-4 mt-1" viewBox="0 0 168 168" aria-hidden="true">
+								<path
+									fill="#1ED760"
+									d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.246-37.49-83.738-83.745-83.738l.001-.004zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.505-97.289-9.684-4.138 1.255-8.514-1.081-9.768-5.219a7.835 7.835 0 015.221-9.771c29.581-8.98 78.756-7.245 109.83 11.202a7.823 7.823 0 012.74 10.733c-2.2 3.722-7.02 4.949-10.73 2.739z"
+								/>
+							</svg>
+						</span>
+					</div>
+				</a>
+			) : (
+				<div className="flex items-center">
+					<Badge
+						variant="outline"
+						className="bg-card-ghost text-card-foreground font-mono text-[11px]"
+					>
+						not playing
+					</Badge>
+					<span className="ml-1">
+						<svg className="h-4 w-4" viewBox="0 0 168 168" aria-hidden="true">
+							<path
+								fill="#1ED760"
+								d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.246-37.49-83.738-83.745-83.738l.001-.004zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.505-97.289-9.684-4.138 1.255-8.514-1.081-9.768-5.219a7.835 7.835 0 015.221-9.771c29.581-8.98 78.756-7.245 109.83 11.202a7.823 7.823 0 012.74 10.733c-2.2 3.722-7.02 4.949-10.73 2.739z"
+							/>
+						</svg>
+					</span>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/src/components/pages/blog/posts-list.tsx
+++ b/src/components/pages/blog/posts-list.tsx
@@ -3,6 +3,7 @@ import { ReactLenis } from 'lenis/react';
 import { useMemo } from 'react';
 import { LuArrowUpRight } from 'react-icons/lu';
 
+import { ImageCard } from '@/components/ui/image-card';
 import { ScrollFadeReveal } from '@/components/ui/section-reveal';
 import { StaggerText } from '@/components/ui/stagger-text';
 import type { BlogPost } from '@/data/blog';
@@ -11,66 +12,50 @@ import { cn } from '@/utils/utils';
 
 function FeaturedPostCard({ post }: { post: BlogPost }) {
 	return (
-		<a
-			href={toBlogSlug(post.slug)}
-			className={cn(
-				'group relative block no-underline text-white rounded-[18px] overflow-hidden',
-				'border border-white/20 bg-gradient-to-br from-white/10 to-white/5 backdrop-blur-md',
-				'transition-[translate,box-shadow,border-color] duration-[550ms] [transition-timing-function:var(--ease-out)]',
-				'hover:-translate-y-[6px] hover:shadow-[0_44px_70px_-30px_rgba(0,0,0,0.36)]',
-				'hover:border-white/40',
-				'motion-reduce:transition-none'
-			)}
-		>
-			<div
-				className="relative overflow-hidden bg-muted"
-				style={{ height: 'clamp(340px, 42vw, 520px)' }}
-			>
-				{post.cover ? (
-					<img
-						src={post.cover}
-						alt=""
-						aria-hidden="true"
-						loading="eager"
-						className="absolute inset-0 w-full h-full object-cover transition-transform duration-[1100ms] [transition-timing-function:var(--ease-out)] group-hover:scale-105 motion-reduce:transition-none"
-					/>
-				) : (
-					<div className="absolute inset-0 bg-gradient-to-br from-muted to-muted/50" />
-				)}
-
-				<div
-					className="absolute inset-0 z-[1] pointer-events-none"
-					style={{ background: 'linear-gradient(180deg, transparent 45%, rgba(15,8,4,0.8) 100%)' }}
-					aria-hidden="true"
-				/>
-
-				<div className="absolute left-0 right-0 bottom-0 z-[3] p-[clamp(20px,2.6vw,32px)]">
-					{post.category && (
-						<span className="inline-block font-mono text-[10px] tracking-[0.06em] uppercase text-orange-300 rounded-full px-[10px] py-[4px] mb-[12px] opacity-0 translate-y-[8px] transition-[opacity,translate] duration-[450ms] [transition-timing-function:var(--ease-out)] group-hover:opacity-100 group-hover:translate-y-0 [@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0 motion-reduce:transition-none">
-							{post.category}
-						</span>
+		<ImageCard href={toBlogSlug(post.slug)} image={post.cover} featured eagerImage>
+			{post.category && (
+				<span
+					className={cn(
+						'inline-block font-mono text-[10px] tracking-[0.06em] uppercase text-white/90 rounded-full px-[10px] py-[4px] mb-[12px]',
+						'bg-white/15 backdrop-blur-[4px]',
+						'opacity-0 translate-y-[8px]',
+						'transition-[opacity,translate] duration-[450ms] [transition-timing-function:var(--ease-out)]',
+						'group-hover:opacity-100 group-hover:translate-y-0',
+						'[@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0',
+						'motion-reduce:transition-none'
 					)}
+				>
+					{post.category}
+				</span>
+			)}
 
-					<h3 className="m-0 font-clash font-medium text-[clamp(34px,5vw,64px)] leading-[1.02] tracking-[-0.025em] text-white transition-[translate] duration-[500ms] [transition-timing-function:var(--ease-out)] group-hover:-translate-y-[2px] motion-reduce:transition-none">
-						{post.title}
-					</h3>
+			<h3 className="m-0 font-clash font-medium text-[clamp(34px,5vw,64px)] leading-[1.02] tracking-[-0.025em] text-white transition-[translate] duration-[500ms] [transition-timing-function:var(--ease-out)] group-hover:-translate-y-[2px] motion-reduce:transition-none">
+				{post.title}
+			</h3>
 
-					<p className="m-0 mt-[10px] font-mono text-[13px] leading-[1.55] text-white/90 max-w-[540px] overflow-hidden max-h-0 opacity-0 transition-[max-height,opacity] duration-[550ms] [transition-timing-function:var(--ease-out)] group-hover:max-h-[80px] group-hover:opacity-100 [@media(hover:none)]:max-h-[90px] [@media(hover:none)]:opacity-100 motion-reduce:max-h-[90px] motion-reduce:opacity-100">
-						{post.description}
-					</p>
+			<p
+				className={cn(
+					'm-0 mt-[10px] font-mono text-[13px] leading-[1.55] text-white/90 max-w-[540px] overflow-hidden',
+					'max-h-0 opacity-0',
+					'transition-[max-height,opacity] duration-[550ms] [transition-timing-function:var(--ease-out)]',
+					'group-hover:max-h-[80px] group-hover:opacity-100',
+					'[@media(hover:none)]:max-h-[90px] [@media(hover:none)]:opacity-100',
+					'motion-reduce:max-h-[90px] motion-reduce:opacity-100'
+				)}
+			>
+				{post.description}
+			</p>
 
-					<div className="flex items-center gap-[14px] mt-[16px] text-white/75 font-mono text-[12px]">
-						<span>{format(new Date(post.date), 'do MMMM yyyy')}</span>
-						{post.readingTime && (
-							<>
-								<span>·</span>
-								<span>{post.readingTime} min read</span>
-							</>
-						)}
-					</div>
-				</div>
+			<div className="flex items-center gap-[14px] mt-[16px] text-white/75 font-mono text-[12px]">
+				<span>{format(new Date(post.date), 'do MMMM yyyy')}</span>
+				{post.readingTime && (
+					<>
+						<span>·</span>
+						<span>{post.readingTime} min read</span>
+					</>
+				)}
 			</div>
-		</a>
+		</ImageCard>
 	);
 }
 

--- a/src/components/pages/blog/posts-list.tsx
+++ b/src/components/pages/blog/posts-list.tsx
@@ -70,7 +70,7 @@ export default function PostsList({ posts }: { posts: BlogPost[] }) {
 
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<div className="mx-auto w-full max-w-[1180px] px-[max(24px,4vw)]">
+			<div className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)]">
 				<header className="pt-[clamp(100px,14vw,138px)]">
 					<ScrollFadeReveal onLoadVisibility>
 						<div className="flex items-center gap-[12px] font-mono text-[12px] tracking-[0.06em] uppercase text-[var(--color-orange-primary)] mb-[22px]">
@@ -80,7 +80,7 @@ export default function PostsList({ posts }: { posts: BlogPost[] }) {
 							/>
 							Journal · {new Date().getFullYear()}
 						</div>
-						<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,128px)] leading-[0.9] tracking-[-0.038em] text-foreground">
+						<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,128px)] leading-[0.9] tracking-[-0.038em] text-foreground break-words">
 							<StaggerText
 								text="Thoughts & Essays"
 								autoReveal

--- a/src/components/pages/home/layout.tsx
+++ b/src/components/pages/home/layout.tsx
@@ -11,7 +11,7 @@ import type { Project } from '@/data/projects';
 export const HomeLayout = ({ projects }: { projects: Project[] }) => {
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<section className="mx-auto w-full max-w-[1100px] space-y-64 md:space-y-48 print:space-y-6 animate-fade-in-left delay-500">
+			<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] overflow-x-clip space-y-64 md:space-y-48 print:space-y-6 animate-fade-in-left delay-500">
 				<ScrollFadeReveal onLoadVisibility>
 					<SectionHero />
 				</ScrollFadeReveal>

--- a/src/components/pages/home/section-contact.tsx
+++ b/src/components/pages/home/section-contact.tsx
@@ -134,7 +134,7 @@ export const SectionContact = () => {
 				>
 					<h2
 						ref={headRef}
-						className="m-0 font-clash font-medium text-[clamp(46px,8vw,104px)] leading-[0.95] tracking-[-0.035em] text-[#2e1305] will-change-transform"
+						className="m-0 font-clash font-medium text-[clamp(46px,8vw,104px)] leading-[0.95] tracking-[-0.035em] text-[#2e1305] break-words will-change-transform"
 					>
 						Let's make
 						<br />

--- a/src/components/pages/home/section-hero.tsx
+++ b/src/components/pages/home/section-hero.tsx
@@ -1,6 +1,5 @@
 import { useRef } from 'react';
 
-import { NowPlaying } from '@/components/now-playing';
 import { AnimatedMottos } from '@/components/pages/home/motto';
 import { Section } from '@/components/ui/section';
 import { data } from '@/data/main';
@@ -172,7 +171,7 @@ export const SectionHero = () => {
 						</div>
 					</div>
 
-					<NowPlaying />
+					{/* TODO: decide between hero widget vs navbar badge */}
 				</div>
 			</div>
 

--- a/src/components/pages/home/section-work-experience.tsx
+++ b/src/components/pages/home/section-work-experience.tsx
@@ -43,7 +43,7 @@ export const SectionWorkExperience = () => {
 										href={link}
 										target="_blank"
 										rel="noreferrer"
-										className="text-foreground no-underline hover:underline hover:[text-decoration-color:var(--color-orange-primary)] [text-underline-offset:3px]"
+										className="text-foreground no-underline hover:text-[var(--color-orange-primary)] hover:underline hover:[text-decoration-color:var(--color-orange-primary)] [text-underline-offset:3px] transition-colors"
 									>
 										{company}
 									</a>

--- a/src/components/pages/projects/index.tsx
+++ b/src/components/pages/projects/index.tsx
@@ -101,7 +101,7 @@ export default function ProjectsList({ projects }: { projects: Project[] }) {
 
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<div className="mx-auto w-full max-w-[1180px] px-[max(24px,4vw)]">
+			<div className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)]">
 				<header className="pt-[clamp(100px,14vw,138px)]">
 					<ScrollFadeReveal onLoadVisibility>
 						<div className="flex items-center gap-[12px] font-mono text-[12px] tracking-[0.06em] uppercase text-[var(--color-orange-primary)] mb-[22px]">
@@ -111,7 +111,7 @@ export default function ProjectsList({ projects }: { projects: Project[] }) {
 							/>
 							Selected work · 2022—{new Date().getFullYear()}
 						</div>
-						<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,128px)] leading-[0.9] tracking-[-0.038em] text-foreground">
+						<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,128px)] leading-[0.9] tracking-[-0.038em] text-foreground break-words">
 							<StaggerText text="Things I've" autoReveal baseDelay={0.08} letterDelay={0.028} />
 							<br />
 							<em className="not-italic font-normal italic text-[var(--color-orange-primary)]">

--- a/src/components/pages/projects/index.tsx
+++ b/src/components/pages/projects/index.tsx
@@ -2,6 +2,7 @@ import { ReactLenis } from 'lenis/react';
 import { useMemo, useState } from 'react';
 import { LuArrowUpRight } from 'react-icons/lu';
 
+import { ImageCard } from '@/components/ui/image-card';
 import { ScrollFadeReveal } from '@/components/ui/section-reveal';
 import { StaggerText } from '@/components/ui/stagger-text';
 import type { Project } from '@/data/projects';
@@ -13,139 +14,66 @@ function ProjectCard({ project, i, featured }: { project: Project; i: number; fe
 		: undefined;
 
 	return (
-		<a
+		<ImageCard
 			href={`/projects/${project.slug}`}
-			className={cn(
-				'group relative block no-underline text-foreground border border-border rounded-[18px] overflow-hidden',
-				'bg-[color-mix(in_srgb,var(--card)_42%,transparent)] shadow-[var(--shadow-card)]',
-				'transition-[translate,box-shadow,border-color] duration-[550ms] [transition-timing-function:var(--ease-out)] will-change-transform',
-				'hover:-translate-y-[6px] hover:shadow-[0_44px_70px_-30px_rgba(0,0,0,0.36)]',
-				'hover:border-[color-mix(in_srgb,var(--color-orange-primary)_40%,var(--border))]',
-				'motion-reduce:transition-none',
-				'animate-[px-in_0.5s_var(--ease-out)_both]',
-				featured && 'col-span-full'
-			)}
-			style={{ animationDelay: `${i * 0.05}s` }}
+			image={project.hero}
+			gradient={gradient}
+			featured={featured}
+			index={i}
+			eagerImage={featured}
 		>
-			<div
-				className="relative overflow-hidden bg-muted"
-				style={{ height: featured ? 'clamp(340px, 42vw, 520px)' : '300px' }}
+			<span
+				className={cn(
+					'inline-block font-mono text-[10px] tracking-[0.06em] uppercase text-white/90 rounded-full px-[10px] py-[4px] mb-[12px]',
+					'bg-white/15 backdrop-blur-[4px]',
+					'opacity-0 translate-y-[8px]',
+					'transition-[opacity,translate] duration-[450ms] [transition-timing-function:var(--ease-out)]',
+					'group-hover:opacity-100 group-hover:translate-y-0',
+					'[@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0',
+					'motion-reduce:transition-none'
+				)}
 			>
-				{gradient ? (
-					<div
-						className="absolute inset-0 transition-transform duration-[1100ms] [transition-timing-function:var(--ease-out)] group-hover:scale-105 motion-reduce:transition-none"
-						style={{ background: gradient }}
-					/>
-				) : (
-					<div className="absolute inset-0 bg-muted" />
+				{project.medium}
+			</span>
+
+			<h3
+				className={cn(
+					'm-0 font-clash font-medium leading-[1.02] tracking-[-0.025em] text-white',
+					'transition-[translate] duration-[500ms] [transition-timing-function:var(--ease-out)] group-hover:-translate-y-[2px]',
+					'motion-reduce:transition-none',
+					featured ? 'text-[clamp(34px,5vw,64px)]' : 'text-[clamp(24px,3vw,38px)]'
 				)}
+			>
+				{project.title}
+			</h3>
 
-				{project.hero && (
-					<img
-						src={project.hero}
-						alt=""
-						aria-hidden="true"
-						loading={featured ? 'eager' : 'lazy'}
-						className="absolute inset-0 w-full h-full object-cover transition-transform duration-[1100ms] [transition-timing-function:var(--ease-out)] group-hover:scale-105 motion-reduce:transition-none"
-					/>
+			<p
+				className={cn(
+					'm-0 mt-[10px] font-mono text-[13px] leading-[1.55] text-white/90 max-w-[440px] overflow-hidden',
+					'max-h-0 opacity-0',
+					'transition-[max-height,opacity] duration-[550ms] [transition-timing-function:var(--ease-out)]',
+					'group-hover:max-h-[80px] group-hover:opacity-100',
+					'[@media(hover:none)]:max-h-[90px] [@media(hover:none)]:opacity-100',
+					'motion-reduce:max-h-[90px] motion-reduce:opacity-100'
 				)}
+			>
+				{project.description}
+			</p>
 
-				<div
-					className={cn(
-						'absolute inset-0 z-[1] pointer-events-none',
-						'[clip-path:polygon(0%_100%,100%_100%,100%_100%,0%_100%)]',
-						'group-hover:[clip-path:polygon(0%_0%,100%_0%,100%_100%,0%_100%)]',
-						'transition-[clip-path] duration-[600ms] [transition-timing-function:var(--ease-out)]',
-						'motion-reduce:hidden'
-					)}
-					style={{
-						background:
-							'linear-gradient(120deg, color-mix(in srgb, var(--color-orange-primary) 90%, transparent), color-mix(in srgb, var(--color-orange-primary) 45%, transparent) 60%, rgba(20,8,3,0.35))'
-					}}
-					aria-hidden="true"
-				/>
-
-				<div
-					className="absolute inset-0 z-[1] pointer-events-none"
-					style={{ background: 'linear-gradient(180deg, transparent 45%, rgba(15,8,4,0.6) 100%)' }}
-					aria-hidden="true"
-				/>
-
-				<span className="absolute top-[16px] left-[18px] z-[3] font-mono text-[12px] text-white/85">
-					{String(i + 1).padStart(2, '0')}
-				</span>
-
-				<span
-					className={cn(
-						'absolute top-[14px] right-[14px] z-[3] w-[40px] h-[40px] rounded-full grid place-items-center',
-						'text-[var(--color-orange-primary)] border border-border backdrop-blur-[6px]',
-						'bg-[color-mix(in_srgb,var(--background)_78%,transparent)]',
-						'opacity-0 scale-[0.8] -rotate-12',
-						'transition-[opacity,scale,rotate,background-color,border-color] duration-[500ms] [transition-timing-function:var(--ease-out)]',
-						'group-hover:opacity-100 group-hover:scale-100 group-hover:rotate-0 group-hover:bg-white group-hover:border-white',
-						'[@media(hover:none)]:opacity-100 [@media(hover:none)]:scale-100 [@media(hover:none)]:rotate-0',
-						'motion-reduce:transition-none'
-					)}
-					aria-hidden="true"
-				>
-					<LuArrowUpRight className="w-[18px] h-[18px]" />
-				</span>
-
-				<div className="absolute left-0 right-0 bottom-0 z-[3] p-[clamp(20px,2.6vw,32px)]">
-					<span
-						className={cn(
-							'inline-block font-mono text-[10px] tracking-[0.06em] uppercase text-[#2e1305] rounded-full px-[10px] py-[4px] mb-[12px]',
-							'opacity-0 translate-y-[8px]',
-							'transition-[opacity,translate] duration-[450ms] [transition-timing-function:var(--ease-out)]',
-							'group-hover:opacity-100 group-hover:translate-y-0',
-							'[@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0',
-							'motion-reduce:transition-none'
-						)}
-						style={{ background: 'color-mix(in srgb, var(--color-orange-light) 92%, #fff)' }}
-					>
-						{project.medium}
-					</span>
-
-					<h3
-						className={cn(
-							'm-0 font-clash font-medium leading-[1.02] tracking-[-0.025em] text-white',
-							'transition-[translate] duration-[500ms] [transition-timing-function:var(--ease-out)] group-hover:-translate-y-[2px]',
-							'motion-reduce:transition-none',
-							featured ? 'text-[clamp(34px,5vw,64px)]' : 'text-[clamp(24px,3vw,38px)]'
-						)}
-					>
-						{project.title}
-					</h3>
-
-					<p
-						className={cn(
-							'm-0 mt-[10px] font-mono text-[13px] leading-[1.55] text-white/90 max-w-[440px] overflow-hidden',
-							'max-h-0 opacity-0',
-							'transition-[max-height,opacity] duration-[550ms] [transition-timing-function:var(--ease-out)]',
-							'group-hover:max-h-[80px] group-hover:opacity-100',
-							'[@media(hover:none)]:max-h-[90px] [@media(hover:none)]:opacity-100',
-							'motion-reduce:max-h-[90px] motion-reduce:opacity-100'
-						)}
-					>
-						{project.description}
-					</p>
-
-					<div className="flex items-center gap-[14px] mt-[16px]">
-						<div className="flex gap-[6px] flex-wrap">
-							{project.tags.map((tag) => (
-								<span
-									key={tag}
-									className="font-mono text-[10px] text-white border border-white/40 rounded-full px-[9px] py-[3px]"
-								>
-									{tag}
-								</span>
-							))}
-						</div>
-						<span className="font-mono text-[11px] text-white/75 ml-auto">{project.year}</span>
-					</div>
+			<div className="flex items-center gap-[14px] mt-[16px]">
+				<div className="flex gap-[6px] flex-wrap">
+					{project.tags.map((tag) => (
+						<span
+							key={tag}
+							className="font-mono text-[10px] text-white border border-white/40 rounded-full px-[9px] py-[3px]"
+						>
+							{tag}
+						</span>
+					))}
 				</div>
+				<span className="font-mono text-[11px] text-white/75 ml-auto">{project.year}</span>
 			</div>
-		</a>
+		</ImageCard>
 	);
 }
 

--- a/src/components/ui/chip.tsx
+++ b/src/components/ui/chip.tsx
@@ -12,10 +12,9 @@ export function Chip({ children, interactive = false, className }: ChipProps) {
 	return (
 		<span
 			className={cn(
-				'inline-flex items-center font-mono text-[10px] font-medium border border-border rounded-full px-[9px] py-[3px] text-foreground',
-				'transition-[border-color,color,background] duration-[250ms] ease-linear',
-				interactive &&
-					'hover:border-[var(--color-orange-primary)] hover:text-[var(--color-orange-primary)]',
+				'inline-flex items-center select-none font-mono text-[10px] font-medium border border-border rounded-full px-[9px] py-[3px] text-foreground',
+				'transition-[border-color,background-color] duration-[250ms] ease-linear',
+				interactive && 'hover:border-foreground/25 hover:bg-foreground/[0.06]',
 				className
 			)}
 		>

--- a/src/components/ui/image-card.tsx
+++ b/src/components/ui/image-card.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react';
+import { LuArrowUpRight } from 'react-icons/lu';
+
+import { cn } from '@/utils/utils';
+
+const FEATURED_HEIGHT = 'clamp(340px, 42vw, 520px)';
+const DEFAULT_HEIGHT = '300px';
+
+type ImageCardProps = {
+	href: string;
+	image?: string | null;
+	gradient?: string;
+	featured?: boolean;
+	index?: number;
+	eagerImage?: boolean;
+	showArrow?: boolean;
+	children: ReactNode;
+};
+
+export function ImageCard({
+	href,
+	image,
+	gradient,
+	featured = false,
+	index,
+	eagerImage = false,
+	showArrow = true,
+	children
+}: ImageCardProps) {
+	return (
+		<a
+			href={href}
+			className={cn(
+				'group relative block no-underline text-foreground border border-border rounded-[18px] overflow-hidden',
+				'bg-[color-mix(in_srgb,var(--card)_42%,transparent)] shadow-[var(--shadow-card)]',
+				'transition-[translate,box-shadow] duration-[550ms] [transition-timing-function:var(--ease-out)] will-change-transform',
+				'hover:-translate-y-[6px] hover:shadow-[0_44px_70px_-30px_rgba(0,0,0,0.36)]',
+				'motion-reduce:transition-none',
+				'animate-[px-in_0.5s_var(--ease-out)_both]',
+				featured && 'col-span-full'
+			)}
+			style={{ animationDelay: index ? `${index * 0.05}s` : undefined }}
+		>
+			<div
+				className="relative overflow-hidden bg-muted"
+				style={{ height: featured ? FEATURED_HEIGHT : DEFAULT_HEIGHT }}
+			>
+				{gradient ? (
+					<div
+						className="absolute inset-0 transition-transform duration-[1100ms] [transition-timing-function:var(--ease-out)] group-hover:scale-105 motion-reduce:transition-none"
+						style={{ background: gradient }}
+					/>
+				) : (
+					<div className="absolute inset-0 bg-gradient-to-br from-muted to-muted/50" />
+				)}
+
+				{image && (
+					<img
+						src={image}
+						alt=""
+						aria-hidden="true"
+						loading={eagerImage ? 'eager' : 'lazy'}
+						className="absolute inset-0 w-full h-full object-cover transition-transform duration-[1100ms] [transition-timing-function:var(--ease-out)] group-hover:scale-105 motion-reduce:transition-none"
+					/>
+				)}
+
+				{/* Hover darkening overlay */}
+				<div
+					className={cn(
+						'absolute inset-0 z-[1] pointer-events-none',
+						'transition-opacity duration-[600ms] [transition-timing-function:var(--ease-out)]',
+						'opacity-0 group-hover:opacity-100',
+						'motion-reduce:hidden'
+					)}
+					style={{
+						background: 'linear-gradient(180deg, rgba(0,0,0,0.08) 0%, rgba(0,0,0,0.18) 100%)'
+					}}
+					aria-hidden="true"
+				/>
+
+				{/* Bottom gradient scrim */}
+				<div
+					className="absolute inset-0 z-[1] pointer-events-none"
+					style={{
+						background: 'linear-gradient(180deg, transparent 40%, rgba(10,6,2,0.65) 100%)'
+					}}
+					aria-hidden="true"
+				/>
+
+				{/* Index number */}
+				{index != null && (
+					<span className="absolute top-[16px] left-[18px] z-[3] font-mono text-[12px] text-white/85">
+						{String(index + 1).padStart(2, '0')}
+					</span>
+				)}
+
+				{/* Arrow button */}
+				{showArrow && (
+					<span
+						className={cn(
+							'absolute top-[14px] right-[14px] z-[3] w-[40px] h-[40px] rounded-full grid place-items-center',
+							'text-[var(--color-orange-primary)] border border-border backdrop-blur-[6px]',
+							'bg-[color-mix(in_srgb,var(--background)_78%,transparent)]',
+							'opacity-0 scale-[0.8] -rotate-12',
+							'transition-[opacity,scale,rotate,background-color,border-color] duration-[500ms] [transition-timing-function:var(--ease-out)]',
+							'group-hover:opacity-100 group-hover:scale-100 group-hover:rotate-0 group-hover:bg-white group-hover:border-white',
+							'[@media(hover:none)]:opacity-100 [@media(hover:none)]:scale-100 [@media(hover:none)]:rotate-0',
+							'motion-reduce:transition-none'
+						)}
+						aria-hidden="true"
+					>
+						<LuArrowUpRight className="w-[18px] h-[18px]" />
+					</span>
+				)}
+
+				{/* Content overlay */}
+				<div className="absolute left-0 right-0 bottom-0 z-[3] p-[clamp(20px,2.6vw,32px)]">
+					{children}
+				</div>
+			</div>
+		</a>
+	);
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,6 +9,7 @@ export * from './dropdown-menu';
 export * from './empty-state';
 export * from './entry-card';
 export * from './eyebrow';
+export * from './image-card';
 export * from './image-frame';
 export * from './input';
 export * from './label';

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -13,7 +13,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 				<input
 					type={type}
 					className={cn(
-						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] text-foreground placeholder:text-muted-foreground/80 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] disabled:cursor-not-allowed disabled:opacity-50',
+						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.5] text-foreground placeholder:text-muted-foreground outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] disabled:cursor-not-allowed disabled:opacity-50',
 						className
 					)}
 					ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/utils/utils';
 
 const labelVariants = cva(
-	'font-mono text-[11px] tracking-[0.08em] uppercase text-muted-foreground mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)] peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+	'font-mono text-[11px] tracking-[0.08em] uppercase text-foreground/65 mb-[9px] transition-colors duration-[250ms] group-focus-within:text-[var(--color-orange-primary)] peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 );
 
 const Label = React.forwardRef<

--- a/src/components/ui/section-heading.tsx
+++ b/src/components/ui/section-heading.tsx
@@ -45,7 +45,7 @@ export function SectionHeading({ num, title, count, className }: SectionHeadingP
 					{num}
 				</span>
 			)}
-			<h2 className="m-0 font-clash text-3xl font-bold tracking-[-0.015em] leading-none">
+			<h2 className="m-0 font-clash text-3xl font-bold tracking-[-0.015em] leading-none shrink-0">
 				<StaggerText text={title} revealed={revealed} baseDelay={0.05} letterDelay={0.03} />
 			</h2>
 			<div

--- a/src/components/ui/stagger-text.tsx
+++ b/src/components/ui/stagger-text.tsx
@@ -32,7 +32,7 @@ export function StaggerText({
 		<span className={className}>
 			{words.map((word, wi) => (
 				<span key={wi}>
-					<span className="inline-block overflow-hidden align-top [padding:0.12em_0.04em_0.18em] [margin:-0.12em_-0.04em_-0.18em]">
+					<span className="inline-block overflow-hidden align-top [padding:0.12em_0.12em_0.18em] [margin:-0.12em_-0.12em_-0.18em]">
 						{[...word].map((ch) => {
 							charIndex++;
 							return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,7 +12,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 			<>
 				<textarea
 					className={cn(
-						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.6] text-foreground placeholder:text-muted-foreground/80 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] min-h-[132px] resize-vertical disabled:cursor-not-allowed disabled:opacity-50',
+						'w-full rounded-[12px] border border-border bg-background px-[15px] py-[13px] font-mono text-[14px] leading-[1.6] text-foreground placeholder:text-muted-foreground outline-none focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:border-[var(--color-orange-primary)] focus-visible:shadow-[0_0_0_4px_color-mix(in_srgb,var(--color-orange-primary)_14%,transparent)] transition-[border-color,box-shadow] duration-[250ms] min-h-[132px] resize-vertical disabled:cursor-not-allowed disabled:opacity-50',
 						className
 					)}
 					ref={ref}

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -86,7 +86,7 @@ function BlogShowRoute() {
 
 	return (
 		<article className="w-full">
-			<header className="mx-auto w-full max-w-4xl px-4 pt-[132px] sm:px-6">
+			<header className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] pt-[132px]">
 				<Link
 					to={ROUTES.blog}
 					className="mb-[30px] inline-flex items-center gap-2 font-mono text-xs text-muted-foreground no-underline whitespace-nowrap transition-colors duration-300 hover:gap-[11px] hover:text-[var(--color-orange-primary)] sm:text-sm"
@@ -107,7 +107,7 @@ function BlogShowRoute() {
 					<span className="whitespace-nowrap">{formattedDate}</span>
 				</div>
 
-				<h1 className="animate-fade-in-left delay-200 m-0 font-clash text-foreground font-medium leading-[0.98] tracking-[-0.03em] text-[clamp(40px,6.4vw,78px)]">
+				<h1 className="animate-fade-in-left delay-200 m-0 font-clash text-foreground font-medium leading-[0.98] tracking-[-0.03em] text-[clamp(40px,6.4vw,78px)] break-words">
 					{title}
 				</h1>
 
@@ -121,7 +121,7 @@ function BlogShowRoute() {
 			{coverImage?.url && <Cover src={coverImage.url} alt={coverImage.alt ?? title} />}
 
 			{structuredBody && (
-				<div className="mx-auto w-full max-w-4xl px-4 a-body sm:px-6">
+				<div className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] a-body">
 					<PortableTextRenderer body={structuredBody} />
 				</div>
 			)}
@@ -133,7 +133,7 @@ function BlogShowRoute() {
 					<Link
 						to="/blog/$slug"
 						params={{ slug: nextPost.slug }}
-						className="mx-auto block max-w-[1100px] p-[clamp(40px,7vw,80px)_max(24px,4vw)] text-foreground no-underline"
+						className="mx-auto block max-w-[1100px] p-[clamp(40px,7vw,80px)_var(--content-inset)] text-foreground no-underline"
 					>
 						<div className="font-mono text-xs uppercase tracking-[0.1em] text-muted-foreground">
 							Next in the journal
@@ -157,7 +157,7 @@ function ArticleFooter({ author }: { author?: { name: string; avatar?: string; u
 	if (!author) return null;
 
 	return (
-		<footer className="mx-auto w-full max-w-4xl px-4 mt-[clamp(48px,7vw,80px)] sm:px-6">
+		<footer className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(48px,7vw,80px)]">
 			<div className="flex items-center gap-4">
 				{author.avatar && (
 					<img

--- a/src/routes/contact.tsx
+++ b/src/routes/contact.tsx
@@ -35,9 +35,9 @@ function ContactRoute(): JSX.Element {
 
 	return (
 		<ReactLenis root options={{ syncTouch: true }}>
-			<div className="mx-auto w-full max-w-[1100px] animate-fade-in-left delay-500">
+			<div className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] animate-fade-in-left delay-500">
 				<header className="pt-8 pb-[clamp(56px,9vw,104px)]">
-					<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,112px)] leading-[0.92] tracking-[-0.038em]">
+					<h1 className="m-0 font-clash font-medium text-[clamp(52px,9.5vw,112px)] leading-[0.92] tracking-[-0.038em] break-words">
 						<StaggerText
 							text="Let's make"
 							revealed={revealed}

--- a/src/routes/projects/$slug.tsx
+++ b/src/routes/projects/$slug.tsx
@@ -197,8 +197,8 @@ function ProjectItemRoute() {
 
 	return (
 		<article className="w-full">
-			<header className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] pt-[132px]">
-				<div className="mx-auto max-w-[760px]">
+			<header className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] pt-[132px]">
+				<div>
 					<Link
 						to={ROUTES.projects}
 						className="mb-[30px] inline-flex items-center gap-2 font-mono text-xs text-muted-foreground no-underline whitespace-nowrap transition-colors duration-300 hover:gap-[11px] hover:text-[var(--color-orange-primary)] sm:text-sm"
@@ -216,7 +216,7 @@ function ProjectItemRoute() {
 						<span>{year}</span>
 					</div>
 
-					<h1 className="animate-fade-in-left delay-200 m-0 font-clash text-foreground font-medium leading-[0.92] tracking-[-0.035em] text-[clamp(54px,10vw,132px)] break-keep">
+					<h1 className="animate-fade-in-left delay-200 m-0 font-clash text-foreground font-medium leading-[0.92] tracking-[-0.035em] text-[clamp(54px,10vw,132px)] break-words">
 						<StaggerText text={title} autoReveal baseDelay={0.05} letterDelay={0.03} />
 					</h1>
 
@@ -331,7 +331,7 @@ function ProjectItemRoute() {
 			)}
 
 			{(overview || problem || approach) && (
-				<section className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-[clamp(80px,12vw,150px)]">
+				<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(80px,12vw,150px)]">
 					<div className="mx-auto max-w-[760px]">
 						{overview && <CaseStudyBlock label="Overview" text={overview} />}
 						{problem && (
@@ -355,7 +355,7 @@ function ProjectItemRoute() {
 			{statistics.length > 0 && <StatisticsGrid statistics={statistics} />}
 
 			{structuredBody && (
-				<section className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-[clamp(60px,9vw,110px)]">
+				<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(60px,9vw,110px)]">
 					<div className="mx-auto max-w-[760px]">
 						<PortableTextRenderer body={structuredBody} className="a-body" />
 					</div>
@@ -395,7 +395,7 @@ function ProjectItemRoute() {
 										/>
 									</div>
 								)}
-								<div className="relative z-[1] mx-auto w-full max-w-[1100px] p-[clamp(48px,9vw,110px)_max(24px,4vw)]">
+								<div className="relative z-[1] mx-auto w-full max-w-[1100px] p-[clamp(48px,9vw,110px)_var(--content-inset)]">
 									<div className="font-mono text-xs tracking-[0.1em] uppercase text-muted-foreground transition-colors duration-[400ms] ease-[var(--ease-out)] group-hover:text-[#5a2a12] dark:group-hover:text-[#e8a67a]">
 										Next project
 									</div>
@@ -450,7 +450,7 @@ function CaseStudyBlock({
 
 function StatisticsGrid({ statistics }: { statistics: ResolvedMetric[] }) {
 	return (
-		<section className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-[clamp(60px,9vw,110px)]">
+		<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(60px,9vw,110px)]">
 			<div className="mx-auto max-w-[760px]">
 				<div className={SECTION_LABEL}>
 					<span className={SECTION_LINE} />
@@ -484,8 +484,8 @@ const GALLERY_LAYOUT_CLASSES: Record<ResolvedGalleryItem['layout'], string> = {
 
 function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
 	return (
-		<section className="mx-auto w-full max-w-[1100px] px-[max(24px,4vw)] mt-[clamp(60px,9vw,110px)]">
-			<div className={cn(SECTION_LABEL, 'mx-auto max-w-[760px]')}>
+		<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(60px,9vw,110px)]">
+			<div className={cn(SECTION_LABEL, 'mx-auto max-w-[1100px]')}>
 				<span className={SECTION_LINE} />
 				Gallery
 			</div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -589,6 +589,11 @@
 		background: var(--color-orange-primary);
 	}
 
+	:root[data-menu-open] .progress {
+		opacity: 0;
+		pointer-events: none;
+	}
+
 	.animate-fade-in-left {
 		@apply animate-in fade-in slide-in-from-left-3.5 duration-1000 fill-mode-both transition-opacity;
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -266,8 +266,7 @@
 }
 
 @utility entry-card {
-	background: color-mix(in srgb, hsl(var(--card)) 72%, transparent);
-	backdrop-filter: blur(2px);
+	background: hsl(var(--card));
 }
 
 @utility bg-card-ghost {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -282,27 +282,15 @@
 }
 
 @utility nav-bg {
-	background: linear-gradient(
-		to right,
-		color-mix(in srgb, hsl(var(--background)) 72%, transparent),
-		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 12%,
-		color-mix(in srgb, hsl(var(--background)) 92%, transparent) 88%,
-		color-mix(in srgb, hsl(var(--background)) 72%, transparent)
-	);
-	backdrop-filter: blur(12px) saturate(1.1);
-	-webkit-backdrop-filter: blur(12px) saturate(1.1);
+	background: transparent;
+	backdrop-filter: blur(6px);
+	-webkit-backdrop-filter: blur(6px);
 }
 
 @utility nav-bg-scrolled {
-	background: linear-gradient(
-		to right,
-		color-mix(in srgb, hsl(var(--background)) 72%, transparent),
-		color-mix(in srgb, hsl(var(--background)) 96%, transparent) 12%,
-		color-mix(in srgb, hsl(var(--background)) 96%, transparent) 88%,
-		color-mix(in srgb, hsl(var(--background)) 72%, transparent)
-	);
-	backdrop-filter: blur(12px) saturate(1.2);
-	-webkit-backdrop-filter: blur(12px) saturate(1.2);
+	background: color-mix(in srgb, hsl(var(--background)) 40%, transparent);
+	backdrop-filter: blur(10px) saturate(1.1);
+	-webkit-backdrop-filter: blur(10px) saturate(1.1);
 }
 
 @utility nav-overlay-open {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -447,6 +447,9 @@
 		--color-orange-dark-border: #4d2512;
 		/* Navigation */
 		--nav-border: #f3c6a7;
+		/* Layout */
+		--sideline-inset: max(14px, 4vw);
+		--content-inset: calc(var(--sideline-inset) + 15px);
 		/* Font stacks */
 		--font-display: "ClashDisplay", "DM Sans", sans-serif;
 		--font-mono: "JetBrains Mono", "Fira Code", "Courier New", monospace;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -266,7 +266,7 @@
 }
 
 @utility entry-card {
-	background: color-mix(in srgb, hsl(var(--card)) 42%, transparent);
+	background: color-mix(in srgb, hsl(var(--card)) 72%, transparent);
 	backdrop-filter: blur(2px);
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,10 +8,7 @@ const config: Config = {
 	theme: {
 		container: {
 			center: true,
-			padding: {
-				DEFAULT: '0.75rem',
-				sm: '2rem'
-			},
+			padding: '0px',
 			screens: {
 				'2xl': '1400px'
 			}


### PR DESCRIPTION
## What

Visual polish pass addressing element cohesion, contrast, mobile nav UX, and layout consistency across the portfolio.

- **ImageCard extraction** — shared card component for project and blog cards, replacing the orange overlay with a subtle dark scrim
- **Form & card contrast** — bumped `entry-card` opacity from 42% to 72%, improved label and placeholder contrast
- **Chip hover** — replaced orange color change with subtle background fill, disabled text selection
- **Mobile nav** — scroll lock via Lenis, staggered text/blur-in animations, grid fade mask, hamburger hover pinch, progress bar and command FAB hidden when open
- **Layout inset system** — `--sideline-inset` and `--content-inset` CSS variables for consistent spacing relative to decorative orange sidelines across all pages
- **Footer** — flex-wrap with centered layout on mobile
- **Version bump** — v2.0.0

## Linear
Closes PER-54

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally