### PR TITLE
fix 🐛 : navbar, meta titles, and alignment fixes (PER-54)

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -83,7 +83,7 @@ export function Navbar() {
 					hidden ? '-translate-y-[130%] opacity-0' : 'translate-y-0 opacity-100'
 				)}
 			>
-				<div className="max-w-[1100px] mx-auto px-[var(--sideline-inset)] pb-[9px] flex items-center justify-between gap-[10px]">
+				<div className="max-w-[1100px] mx-auto px-[var(--content-inset)] pb-[9px] flex items-center justify-between gap-[10px]">
 					<div className="flex items-center gap-1 min-w-0">
 						<Link
 							to={ROUTES.home}

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -30,7 +30,7 @@ export const Route = createFileRoute('/blog/$slug')({
 		const seo = post?.seo;
 		const canonical = post?.canonicalUrl ?? `${BASE_URL}${toBlogSlug(params.slug)}`;
 		return createSeoHead({
-			title: seo?.title ?? `${post?.title ?? 'Not found'} | Blog`,
+			title: seo?.title ?? `Maria Adriana | ${post?.title ?? 'Not found'}`,
 			description:
 				seo?.description ?? post?.description ?? 'The requested blog post could not be located.',
 			image: seo?.ogImage ?? post?.coverImage?.url,

--- a/src/routes/projects/$slug.tsx
+++ b/src/routes/projects/$slug.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/projects/$slug')({
 		const seo = project?.seo;
 		const url = `${BASE_URL}${toProjectsSlug(params.slug)}`;
 		return createSeoHead({
-			title: seo?.title ?? `${project?.title ?? 'Project'} | Project`,
+			title: seo?.title ?? `Maria Adriana | ${project?.title ?? 'Project'}`,
 			description: seo?.description ?? project?.description ?? 'Project details and information.',
 			image: seo?.ogImage ?? project?.coverImage?.url,
 			url,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -282,14 +282,13 @@
 
 @utility nav-bg {
 	background: transparent;
-	backdrop-filter: blur(6px);
-	-webkit-backdrop-filter: blur(6px);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
 }
 
 @utility nav-bg-scrolled {
-	background: color-mix(in srgb, hsl(var(--background)) 40%, transparent);
-	backdrop-filter: blur(10px) saturate(1.1);
-	-webkit-backdrop-filter: blur(10px) saturate(1.1);
+	backdrop-filter: blur(10px);
+	-webkit-backdrop-filter: blur(10px);
 }
 
 @utility nav-overlay-open {


### PR DESCRIPTION
## What
- Restore transparent navbar with blur-only frosted glass effect (matching deployed site)
- Prefix all page titles with "Maria Adriana |" for consistent branding
- Align navbar horizontal padding with page content inset

## Linear
Closes PER-54

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally