### PR TITLE
Remove legacy Sanity fields (PER-55)

### DIFF
--- a/cms/schemaTypes/project-type.ts
+++ b/cms/schemaTypes/project-type.ts
@@ -136,23 +136,6 @@ export const projectType = defineType({
       description: 'External links — live site, source repo, case study, etc.'
     }),
 
-    // ── Legacy link fields (kept for migration) ────────────────────
-    defineField({
-      name: 'repo',
-      title: 'Repository (legacy)',
-      type: 'string',
-      group: 'meta',
-      description: 'Legacy: repository path. Migrate to links[].',
-      deprecated: {reason: 'Use the links array instead.'}
-    }),
-    defineField({
-      name: 'liveUrl',
-      title: 'Live URL (legacy)',
-      type: 'url',
-      group: 'meta',
-      deprecated: {reason: 'Use the links array instead.'}
-    }),
-
     // ── Case Study ─────────────────────────────────────────────────
     defineField({
       name: 'overview',
@@ -201,26 +184,6 @@ export const projectType = defineType({
       type: 'body',
       group: 'caseStudy',
       description: 'Rich case-study content. Replaces the legacy MDX body.'
-    }),
-
-    // ── Legacy body (kept for migration) ───────────────────────────
-    defineField({
-      name: 'body',
-      title: 'Body — MDX (legacy)',
-      type: 'text',
-      rows: 20,
-      group: 'caseStudy',
-      deprecated: {reason: 'Use structuredBody instead.'}
-    }),
-
-    // ── Legacy hero path (kept for migration) ──────────────────────
-    defineField({
-      name: 'hero',
-      title: 'Hero Image Path (legacy)',
-      type: 'string',
-      group: 'content',
-      description: 'Legacy: public image path. Migrate to coverImage.',
-      deprecated: {reason: 'Use coverImage instead.'}
     }),
 
     // ── SEO ────────────────────────────────────────────────────────

--- a/src/components/pages/home/section-projects.tsx
+++ b/src/components/pages/home/section-projects.tsx
@@ -177,9 +177,9 @@ export const SectionProjects = ({ projects }: { projects: Project[] }) => {
 										background: `linear-gradient(145deg, ${project.colors[0]}, ${project.colors[1] ?? project.colors[0]} 55%, ${project.colors[2] ?? project.colors[0]})`
 									}}
 								/>
-								{project.hero && (
+								{project.coverImage?.url && (
 									<img
-										src={project.hero}
+										src={project.coverImage.url}
 										alt=""
 										className="absolute inset-0 w-full h-full object-cover"
 									/>

--- a/src/components/pages/projects/index.tsx
+++ b/src/components/pages/projects/index.tsx
@@ -16,7 +16,7 @@ function ProjectCard({ project, i, featured }: { project: Project; i: number; fe
 	return (
 		<ImageCard
 			href={`/projects/${project.slug}`}
-			image={project.hero}
+			image={project.coverImage?.url}
 			gradient={gradient}
 			featured={featured}
 			index={i}

--- a/src/data/projects/index.ts
+++ b/src/data/projects/index.ts
@@ -40,20 +40,14 @@ const PROJECT_FIELDS = `
   "statistics": statistics[] { value, label },
   "gallery": gallery[] ${GALLERY_ITEM_PROJECTION},
   "structuredBody": structuredBody ${STRUCTURED_BODY_PROJECTION},
-  "seo": seo ${SEO_PROJECTION},
-  // Legacy fields — still projected until migration completes
-  hero,
-  repo,
-  liveUrl,
-  body
+  "seo": seo ${SEO_PROJECTION}
 `;
 
 const NEXT_PROJECT_FIELDS = `
   title,
   "slug": slug.current,
   colors,
-  "coverImage": coverImage ${RICH_IMAGE_PROJECTION},
-  hero
+  "coverImage": coverImage ${RICH_IMAGE_PROJECTION}
 `;
 
 // ── Sanity response types ─────────────────────────────────────────────
@@ -82,11 +76,6 @@ type SanityProject = {
 	gallery?: ResolvedGalleryItem[];
 	structuredBody?: PortableTextBody;
 	seo?: ResolvedSeo;
-	// Legacy
-	hero?: string;
-	repo?: string;
-	liveUrl?: string;
-	body?: string;
 };
 
 // ── Application model ─────────────────────────────────────────────────
@@ -114,11 +103,6 @@ export interface Project {
 	gallery: ResolvedGalleryItem[];
 	structuredBody?: PortableTextBody;
 	seo?: ResolvedSeo;
-	// Legacy — available until migration completes
-	hero: string;
-	repo: string;
-	liveUrl?: string;
-	content: string;
 }
 
 // ── Normalizer ────────────────────────────────────────────────────────
@@ -148,12 +132,7 @@ function normalizeProject(project: SanityProject): Project {
 		statistics: Array.isArray(project.statistics) ? project.statistics : [],
 		gallery: Array.isArray(project.gallery) ? project.gallery : [],
 		structuredBody: project.structuredBody,
-		seo: project.seo,
-		// Legacy
-		hero: project.coverImage?.url ?? project.hero ?? '',
-		repo: project.repo ?? '',
-		liveUrl: project.liveUrl,
-		content: project.body ?? ''
+		seo: project.seo
 	};
 }
 
@@ -177,7 +156,6 @@ export async function getProject(slug: string): Promise<Project | undefined> {
 export interface NextProject {
 	title: string;
 	slug: string;
-	hero: string;
 	colors?: string[];
 	coverImage?: ResolvedImage;
 }
@@ -206,7 +184,6 @@ function normalizeNextProject(p: SanityProject): NextProject {
 	return {
 		title: p.title,
 		slug: p.slug,
-		hero: p.coverImage?.url ?? p.hero ?? '',
 		colors: Array.isArray(p.colors) ? p.colors : [],
 		coverImage: p.coverImage
 	};


### PR DESCRIPTION
## What
Remove deprecated legacy fields (`hero`, `repo`, `liveUrl`, `body`) from the Sanity schema, GROQ projections, TypeScript types, and component references. All projects now use `coverImage`, `links`, and `structuredBody` exclusively.

## Linear
Closes PER-55

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally