### PR TITLE
feat ✨ : add image lightbox to project gallery (PER-58)

### DIFF
--- a/src/components/ui/lightbox.tsx
+++ b/src/components/ui/lightbox.tsx
@@ -1,0 +1,144 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useCallback, useEffect, useState } from 'react';
+import { LuChevronLeft, LuChevronRight, LuX } from 'react-icons/lu';
+
+import { cn } from '@/utils/utils';
+
+interface LightboxImage {
+	url: string;
+	alt?: string;
+	caption?: string;
+	width?: number;
+	height?: number;
+}
+
+interface LightboxProps {
+	images: LightboxImage[];
+	initialIndex?: number;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+const LIGHTBOX_BTN =
+	'z-10 grid place-items-center rounded-full bg-black/40 text-white/90 backdrop-blur-sm border border-white/15 cursor-pointer transition-[background,scale] duration-200 hover:bg-black/60 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 motion-reduce:transition-none';
+
+function Lightbox({ images, initialIndex = 0, open, onOpenChange }: LightboxProps) {
+	const [index, setIndex] = useState(initialIndex);
+
+	useEffect(() => {
+		if (open) setIndex(initialIndex);
+	}, [open, initialIndex]);
+
+	const hasPrev = index > 0;
+	const hasNext = index < images.length - 1;
+
+	const goPrev = useCallback(() => setIndex((i) => Math.max(0, i - 1)), []);
+	const goNext = useCallback(
+		() => setIndex((i) => Math.min(images.length - 1, i + 1)),
+		[images.length]
+	);
+
+	useEffect(() => {
+		if (!open) return;
+
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'ArrowLeft') {
+				e.preventDefault();
+				goPrev();
+			} else if (e.key === 'ArrowRight') {
+				e.preventDefault();
+				goNext();
+			}
+		};
+
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [open, goPrev, goNext]);
+
+	const current = images[index];
+	if (!current) return null;
+
+	return (
+		<DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+			<DialogPrimitive.Portal>
+				<DialogPrimitive.Overlay
+					className={cn(
+						'fixed inset-0 z-50 bg-black/90 backdrop-blur-sm',
+						'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-200',
+						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:duration-150'
+					)}
+				/>
+				<DialogPrimitive.Content
+					aria-describedby={undefined}
+					className={cn(
+						'fixed inset-0 z-50 flex flex-col items-center justify-center p-[clamp(16px,4vw,48px)] outline-none',
+						'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:duration-200',
+						'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:duration-150'
+					)}
+				>
+					<DialogPrimitive.Title className="sr-only">
+						Image {index + 1} of {images.length}
+					</DialogPrimitive.Title>
+
+					<DialogPrimitive.Close
+						className={cn(LIGHTBOX_BTN, 'absolute top-[16px] right-[16px] size-[40px]')}
+						aria-label="Close lightbox"
+					>
+						<LuX className="size-[18px]" />
+					</DialogPrimitive.Close>
+
+					{images.length > 1 && (
+						<>
+							<button
+								type="button"
+								className={cn(
+									LIGHTBOX_BTN,
+									'absolute top-1/2 -translate-y-1/2 size-[44px] disabled:opacity-30 disabled:pointer-events-none left-[clamp(8px,2vw,24px)]'
+								)}
+								onClick={goPrev}
+								disabled={!hasPrev}
+								aria-label="Previous image"
+							>
+								<LuChevronLeft className="size-[20px]" />
+							</button>
+							<button
+								type="button"
+								className={cn(
+									LIGHTBOX_BTN,
+									'absolute top-1/2 -translate-y-1/2 size-[44px] disabled:opacity-30 disabled:pointer-events-none right-[clamp(8px,2vw,24px)]'
+								)}
+								onClick={goNext}
+								disabled={!hasNext}
+								aria-label="Next image"
+							>
+								<LuChevronRight className="size-[20px]" />
+							</button>
+						</>
+					)}
+
+					<img
+						src={current.url}
+						alt={current.alt ?? ''}
+						width={current.width}
+						height={current.height}
+						className="max-h-[80vh] max-w-full rounded-lg object-contain select-none"
+					/>
+
+					<div className="mt-[14px] flex items-center gap-3 text-center">
+						{current.caption && (
+							<p className="m-0 font-mono text-[12px] text-white/75">{current.caption}</p>
+						)}
+						{images.length > 1 && (
+							<span className="font-mono text-[11px] text-white/45">
+								{index + 1} / {images.length}
+							</span>
+						)}
+					</div>
+				</DialogPrimitive.Content>
+			</DialogPrimitive.Portal>
+		</DialogPrimitive.Root>
+	);
+}
+
+export type { LightboxImage };
+export { Lightbox };

--- a/src/routes/projects/$slug.tsx
+++ b/src/routes/projects/$slug.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, Link, notFound, useNavigate } from '@tanstack/react-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LuArrowUpRight, LuGithub } from 'react-icons/lu';
 
 import { PortableTextRenderer } from '@/components/portable-text';
 import { getStackByName } from '@/components/stacks';
+import type { LightboxImage } from '@/components/ui/lightbox';
+import { Lightbox } from '@/components/ui/lightbox';
 import { NotFoundPage } from '@/components/ui/not-found-page';
 import { StaggerText } from '@/components/ui/stagger-text';
 import { BASE_URL } from '@/data/main';
@@ -483,6 +485,28 @@ const GALLERY_LAYOUT_CLASSES: Record<ResolvedGalleryItem['layout'], string> = {
 };
 
 function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
+	const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+	const validItems = gallery.reduce<{
+		images: LightboxImage[];
+		indexMap: Map<number, number>;
+	}>(
+		(acc, item, i) => {
+			if (item.image?.url) {
+				acc.indexMap.set(i, acc.images.length);
+				acc.images.push({
+					url: item.image.url,
+					alt: item.image.alt ?? undefined,
+					caption: item.image.caption ?? undefined,
+					width: item.image.width,
+					height: item.image.height
+				});
+			}
+			return acc;
+		},
+		{ images: [], indexMap: new Map() }
+	);
+
 	return (
 		<section className="mx-auto w-full max-w-[1100px] px-[var(--content-inset)] mt-[clamp(60px,9vw,110px)]">
 			<div className={cn(SECTION_LABEL, 'mx-auto max-w-[1100px]')}>
@@ -490,12 +514,17 @@ function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
 				Gallery
 			</div>
 			<div className="grid grid-cols-2 gap-[clamp(12px,1.6vw,20px)] max-sm:grid-cols-1">
-				{gallery.map((item) => {
+				{gallery.map((item, i) => {
 					const { image } = item;
 					if (!image?.url) return null;
 					return (
 						<figure key={image.url} className={cn('m-0', GALLERY_LAYOUT_CLASSES[item.layout])}>
-							<div className="overflow-hidden rounded-2xl border border-border bg-muted shadow-[var(--shadow-card)]">
+							<button
+								type="button"
+								className="w-full overflow-hidden rounded-2xl border border-border bg-muted shadow-[var(--shadow-card)] cursor-zoom-in transition-[box-shadow,scale] duration-300 [transition-timing-function:var(--ease-out)] hover:shadow-xl hover:scale-[1.015] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-orange-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none"
+								onClick={() => setActiveIndex(validItems.indexMap.get(i) ?? 0)}
+								aria-label={`View ${image.alt ?? 'gallery image'} fullscreen`}
+							>
 								<img
 									src={image.url}
 									alt={image.alt ?? ''}
@@ -513,7 +542,7 @@ function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
 											}
 										: {})}
 								/>
-							</div>
+							</button>
 							{image.caption && (
 								<figcaption className="mt-[10px] text-center font-mono text-[11.5px] text-muted-foreground">
 									{image.caption}
@@ -523,6 +552,15 @@ function ProjectGallery({ gallery }: { gallery: ResolvedGalleryItem[] }) {
 					);
 				})}
 			</div>
+
+			<Lightbox
+				images={validItems.images}
+				initialIndex={activeIndex ?? 0}
+				open={activeIndex !== null}
+				onOpenChange={(open) => {
+					if (!open) setActiveIndex(null);
+				}}
+			/>
 		</section>
 	);
 }


### PR DESCRIPTION
## What
Add a lightbox overlay to project gallery images. Clicking a gallery image opens it fullscreen with prev/next navigation (arrows + keyboard), caption display, and accessible close button. Uses Radix Dialog for focus trapping and Escape-to-close.

## Linear
Closes PER-58

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally