### PR TITLE
chore 🧰 : trigger coolify deploy automatically after validate passes on main

### DIFF
--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -2,12 +2,17 @@ name: Deploy To Coolify
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Validate"]
+    branches: [main]
+    types: [completed]
 
 permissions:
   contents: read
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/deploy-coolify.yml
+++ b/.github/workflows/deploy-coolify.yml
@@ -20,10 +20,13 @@ jobs:
       - name: Trigger Coolify deploy webhook
         env:
           COOLIFY_DEPLOY_WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}
+          COOLIFY_DEPLOY_TOKEN: ${{ secrets.COOLIFY_DEPLOY_TOKEN }}
         run: |
-          if [ -z "$COOLIFY_DEPLOY_WEBHOOK" ]; then
-            echo "COOLIFY_DEPLOY_WEBHOOK is not set."
+          if [ -z "$COOLIFY_DEPLOY_WEBHOOK" ] || [ -z "$COOLIFY_DEPLOY_TOKEN" ]; then
+            echo "COOLIFY_DEPLOY_WEBHOOK or COOLIFY_DEPLOY_TOKEN is not set."
             exit 1
           fi
 
-          curl --fail --silent --show-error --request POST "$COOLIFY_DEPLOY_WEBHOOK"
+          curl --fail --silent --show-error --request POST \
+            --header "Authorization: Bearer $COOLIFY_DEPLOY_TOKEN" \
+            "$COOLIFY_DEPLOY_WEBHOOK"


### PR DESCRIPTION
## What
Wire up the existing Coolify deploy workflow to trigger automatically on push to `main`, gated behind a passing `Validate` run. Manual `workflow_dispatch` deploys still work.

## Linear
Closes PER-59

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally