### PR TITLE
styles 🎨 : improve homepage on mobile (PER-60)

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -75,6 +75,12 @@ export function Navbar() {
 	const isActive = (path: string) =>
 		path === ROUTES.home ? location.pathname === ROUTES.home : location.pathname.startsWith(path);
 
+	const MOBILE_THEME_TOGGLE_WRAPPER_CLASS = cn(
+		'transition-[opacity,filter] duration-[400ms]',
+		'[transition-timing-function:var(--ease-out)] motion-reduce:transition-none',
+		menuOpen ? 'opacity-100 blur-[0px] delay-[380ms]' : 'opacity-0 blur-[4px] delay-0'
+	);
+
 	return (
 		<>
 			<nav
@@ -121,7 +127,9 @@ export function Navbar() {
 					<div className="flex items-center gap-[7px] shrink-0">
 						<NowPlayingBadge />
 						<LocaleToggle />
-						<ThemeToggle />
+						<div className="hidden sm:block">
+							<ThemeToggle />
+						</div>
 
 						<button
 							className="group sm:hidden relative w-8 h-8 -mr-[8px] cursor-pointer shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-[8px]"
@@ -225,6 +233,9 @@ export function Navbar() {
 				</nav>
 
 				<div className="relative flex items-center flex-wrap gap-4 mt-auto pt-8 font-mono text-[12px]">
+					<div className={MOBILE_THEME_TOGGLE_WRAPPER_CLASS}>
+						<ThemeToggle align="start" side="top" />
+					</div>
 					{data.contact.social.map((s, i) => (
 						<a
 							key={s.name}

--- a/src/components/now-playing-badge.tsx
+++ b/src/components/now-playing-badge.tsx
@@ -1,11 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { Badge } from '@/components/ui/badge';
 import { useLocale } from '@/contexts/locale-context';
 import type { NowPlayingData } from '@/server/routes/api/types/spotify';
 
-const ALBUM_ART_SIZE = 64;
-const BADGE_PADDING_EXPANDED = 12;
-const CONTENT_PADDING = 4;
+const SpotifyLogo = ({ className }: { className: string }) => (
+	<span className="ml-1">
+		<svg className={className} viewBox="0 0 168 168" aria-hidden="true">
+			<path
+				fill="#1ED760"
+				d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.246-37.49-83.738-83.745-83.738l.001-.004zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.505-97.289-9.684-4.138 1.255-8.514-1.081-9.768-5.219a7.835 7.835 0 015.221-9.771c29.581-8.98 78.756-7.245 109.83 11.202a7.823 7.823 0 012.74 10.733c-2.2 3.722-7.02 4.949-10.73 2.739z"
+			/>
+		</svg>
+	</span>
+);
 
 export const NowPlayingBadge = () => {
 	const { t } = useLocale();
@@ -20,31 +28,20 @@ export const NowPlayingBadge = () => {
 			{nowPlaying?.data.isPlaying ? (
 				<a href={nowPlaying?.data.songUrl} target="_blank" rel="noreferrer" className="group block">
 					<div className="flex items-start">
-						<div className="relative h-6 inline-block max-w-[220px] align-top">
+						<div className="relative h-6 inline-block max-w-[180px] sm:max-w-[220px] align-top">
 							<span className="invisible block h-6 px-2 py-0 font-mono text-[11px] font-medium leading-snug truncate">
 								{nowPlaying?.data.title} - {nowPlaying?.data.artist}
 							</span>
 							<Badge
 								variant="outline"
-								className="absolute left-0 top-0 text-card-foreground h-6 w-max max-w-[220px] rounded-[24px] px-2 py-0 sm:left-auto sm:right-0 group-hover:h-24 group-hover:w-[320px] group-hover:max-w-none group-hover:rounded-[10px] group-hover:px-3 group-hover:py-2 group-focus-within:h-24 group-focus-within:w-[320px] group-focus-within:max-w-none group-focus-within:rounded-[10px] group-focus-within:px-3 group-focus-within:py-2 z-10 bg-card-ghost"
-								style={{
-									transition:
-										'width 600ms cubic-bezier(0.22,1,0.36,1), height 600ms cubic-bezier(0.22,1,0.36,1), border-radius 900ms ease-out'
-								}}
+								className="absolute right-0 top-0 z-10 bg-card-ghost text-card-foreground h-6 w-max max-w-[180px] sm:max-w-[220px] rounded-[24px] px-2 py-0 now-playing-transition group-hover:h-24 group-hover:w-[320px] group-hover:max-w-none group-hover:rounded-[10px] group-hover:px-3 group-hover:py-2 group-focus-within:h-24 group-focus-within:w-[320px] group-focus-within:max-w-none group-focus-within:rounded-[10px] group-focus-within:px-3 group-focus-within:py-2"
 							>
-								{/* Blur glow — positioned to land behind the album art in expanded state */}
 								{nowPlaying?.data.albumImageUrl && (
 									<img
 										src={nowPlaying.data.albumImageUrl}
 										alt=""
 										aria-hidden="true"
-										className="absolute opacity-0 object-cover blur-[8px] scale-[1.12] rounded-[9px] pointer-events-none transition-opacity duration-75 group-hover:opacity-40 group-hover:duration-500 group-focus-within:opacity-40 group-focus-within:duration-500"
-										style={{
-											width: ALBUM_ART_SIZE,
-											height: ALBUM_ART_SIZE,
-											left: BADGE_PADDING_EXPANDED + CONTENT_PADDING,
-											top: BADGE_PADDING_EXPANDED + CONTENT_PADDING
-										}}
+										className="absolute w-16 h-16 left-4 top-4 opacity-0 object-cover blur-[8px] scale-[1.12] rounded-[9px] pointer-events-none transition-opacity duration-75 group-hover:opacity-40 group-hover:duration-500 group-focus-within:opacity-40 group-focus-within:duration-500"
 									/>
 								)}
 								<div className="relative flex h-full min-w-0 flex-col justify-center gap-0 overflow-hidden">
@@ -84,14 +81,7 @@ export const NowPlayingBadge = () => {
 								</div>
 							</Badge>
 						</div>
-						<span className="order-first mr-1 ml-0 sm:order-none sm:ml-1 sm:mr-0">
-							<svg className="h-4 w-4 mt-1" viewBox="0 0 168 168" aria-hidden="true">
-								<path
-									fill="#1ED760"
-									d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.246-37.49-83.738-83.745-83.738l.001-.004zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.505-97.289-9.684-4.138 1.255-8.514-1.081-9.768-5.219a7.835 7.835 0 015.221-9.771c29.581-8.98 78.756-7.245 109.83 11.202a7.823 7.823 0 012.74 10.733c-2.2 3.722-7.02 4.949-10.73 2.739z"
-								/>
-							</svg>
-						</span>
+						<SpotifyLogo className="h-4 w-4 mt-1" />
 					</div>
 				</a>
 			) : (
@@ -102,14 +92,7 @@ export const NowPlayingBadge = () => {
 					>
 						{t('components.now-playing.idle')}
 					</Badge>
-					<span className="ml-1">
-						<svg className="h-4 w-4" viewBox="0 0 168 168" aria-hidden="true">
-							<path
-								fill="#1ED760"
-								d="M83.996.277C37.747.277.253 37.77.253 84.019c0 46.251 37.494 83.741 83.743 83.741 46.254 0 83.744-37.49 83.744-83.741 0-46.246-37.49-83.738-83.745-83.738l.001-.004zm38.404 120.78a5.217 5.217 0 01-7.18 1.73c-19.662-12.01-44.414-14.73-73.564-8.07a5.222 5.222 0 01-6.249-3.93 5.213 5.213 0 013.926-6.25c31.9-7.291 59.263-4.15 81.337 9.34 2.46 1.51 3.24 4.72 1.73 7.18zm10.25-22.805c-1.89 3.075-5.91 4.045-8.98 2.155-22.51-13.839-56.823-17.846-83.448-9.764-3.453 1.043-7.1-.903-8.148-4.35a6.538 6.538 0 014.354-8.143c30.413-9.228 68.222-4.758 94.072 11.127 3.07 1.89 4.04 5.91 2.15 8.976v-.001zm.88-23.744c-26.99-16.031-71.52-17.505-97.289-9.684-4.138 1.255-8.514-1.081-9.768-5.219a7.835 7.835 0 015.221-9.771c29.581-8.98 78.756-7.245 109.83 11.202a7.823 7.823 0 012.74 10.733c-2.2 3.722-7.02 4.949-10.73 2.739z"
-							/>
-						</svg>
-					</span>
+					<SpotifyLogo className="h-4 w-4" />
 				</div>
 			)}
 		</div>

--- a/src/components/pages/home/section-education.tsx
+++ b/src/components/pages/home/section-education.tsx
@@ -1,3 +1,4 @@
+import { EntryCard } from '@/components/ui/entry-card';
 import { Section } from '@/components/ui/section';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { useLocale } from '@/contexts/locale-context';
@@ -10,19 +11,7 @@ export const SectionEducation = () => {
 			<SectionHeading num="03" title={t('pages.home.education.heading')} />
 			<div className="flex flex-col gap-[14px]">
 				{data.education.map(({ school, preview, summary, start, end, degree }, i) => (
-					<div
-						key={school}
-						className="entry-card spotlight-border grid grid-cols-[48px_1fr_auto] gap-[18px] p-[22px_22px_22px_20px] border border-border rounded-xl shadow-card"
-						onMouseMove={(e) => {
-							const r = e.currentTarget.getBoundingClientRect();
-							e.currentTarget.style.setProperty('--mouse-x', `${e.clientX - r.left}px`);
-							e.currentTarget.style.setProperty('--mouse-y', `${e.clientY - r.top}px`);
-						}}
-						onMouseLeave={(e) => {
-							e.currentTarget.style.setProperty('--mouse-x', '-999px');
-							e.currentTarget.style.setProperty('--mouse-y', '-999px');
-						}}
-					>
+					<EntryCard key={school}>
 						<div className="w-11 h-11 rounded-[9px] border border-border bg-background grid place-items-center overflow-hidden shrink-0">
 							{preview ? (
 								<img
@@ -56,10 +45,10 @@ export const SectionEducation = () => {
 							{start} — {end}
 						</span>
 
-						<p className="m-0 mt-3 font-mono text-[12.5px] leading-[1.7] text-foreground/90 text-pretty [grid-column:2_/-1]">
+						<p className="m-0 mt-3 font-mono text-[12.5px] leading-[1.7] text-foreground/90 text-pretty [grid-column:1_/-1] sm:[grid-column:2_/-1]">
 							{(translations.data.education[i]?.summary ?? summary).trim()}
 						</p>
-					</div>
+					</EntryCard>
 				))}
 			</div>
 		</Section>

--- a/src/components/pages/home/section-hero.tsx
+++ b/src/components/pages/home/section-hero.tsx
@@ -4,17 +4,26 @@ import { AnimatedMottos } from '@/components/pages/home/motto';
 import { Section } from '@/components/ui/section';
 import { useLocale } from '@/contexts/locale-context';
 import { data } from '@/data/main';
+import { cn } from '@/utils/utils';
 
 const TILT_MAX = 16;
+const AVATAR_SIZE_DESKTOP = 92;
+const AVATAR_SIZE_MOBILE = 150;
 
-export const SectionHero = () => {
-	const { t, translations } = useLocale();
-	const currentWork = data.work.find((w) => w.end === 'Present');
+const WaveBadge = () => (
+	<div
+		className="absolute bottom-[-6px] right-[-6px] w-[30px] h-[30px] rounded-full bg-background border border-border grid place-items-center text-[15px] animate-[hero-wave_3.4s_ease-in-out_infinite] origin-[70%_80%] motion-reduce:animate-none"
+		aria-hidden="true"
+	>
+		👋
+	</div>
+);
+
+const AvatarCard = ({ size, className }: { size: number; className?: string }) => {
 	const avatarRef = useRef<HTMLDivElement>(null);
 	const borderRef = useRef<HTMLDivElement>(null);
 	const shineRef = useRef<HTMLDivElement>(null);
 	const highlightRef = useRef<HTMLDivElement>(null);
-
 	const tiltRaf = useRef(0);
 
 	const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -53,7 +62,63 @@ export const SectionHero = () => {
 	};
 
 	return (
+		<div
+			ref={avatarRef}
+			className={cn('relative w-fit flex-shrink-0 will-change-transform', className)}
+			style={{ transition: 'transform 0.6s var(--ease-out)' }}
+			onMouseMove={handleMouseMove}
+			onMouseLeave={handleMouseLeave}
+		>
+			<div
+				ref={borderRef}
+				className="rounded-[8px] p-px shadow-card"
+				style={{ background: 'hsl(var(--border))', transition: 'background 0.2s ease' }}
+			>
+				<div
+					className="relative rounded-[7px] overflow-hidden bg-background"
+					style={{ width: size, height: size }}
+				>
+					<img
+						className="w-full h-full object-cover block"
+						alt={data.name}
+						src="images/avatar.jpeg"
+						width={size}
+						height={size}
+						loading="eager"
+					/>
+					<div
+						ref={shineRef}
+						className="absolute pointer-events-none mix-blend-overlay opacity-0 will-change-transform"
+						style={{
+							inset: '-50%',
+							backgroundImage:
+								'linear-gradient(105deg, hsla(0,50%,72%,0.9) 0%, hsla(60,50%,72%,0.9) 17%, hsla(120,50%,72%,0.9) 33%, hsla(180,50%,72%,0.9) 50%, hsla(240,50%,72%,0.9) 67%, hsla(300,50%,72%,0.9) 83%, hsla(360,50%,72%,0.9) 100%)',
+							transition: 'opacity 0.4s ease, transform 0.12s ease'
+						}}
+					/>
+					<div
+						ref={highlightRef}
+						className="absolute top-0 left-0 w-[80px] h-[80px] rounded-full pointer-events-none mix-blend-screen opacity-0 will-change-transform"
+						style={{
+							background: 'radial-gradient(circle, rgba(255,255,255,0.2) 0%, transparent 65%)',
+							transition: 'opacity 0.25s ease, transform 0.08s ease'
+						}}
+					/>
+				</div>
+			</div>
+			<WaveBadge />
+		</div>
+	);
+};
+
+export const SectionHero = () => {
+	const { t, translations } = useLocale();
+	const currentWork = data.work.find((w) => w.end === 'Present');
+
+	return (
 		<Section className="mt-20 animate-fade-in delay-100">
+			<AvatarCard size={AVATAR_SIZE_MOBILE} className="sm:hidden mb-[22px]" />
+
 			<h1 className="font-clash font-medium text-[clamp(64px,20vw,116px)] leading-[0.92] tracking-[-0.035em] m-0">
 				<span className="block w-fit pb-[0.04em] bg-[linear-gradient(to_right,var(--color-fg-base)_50%,transparent)] [-webkit-background-clip:text] [background-clip:text] [-webkit-text-fill-color:transparent]">
 					maria
@@ -122,58 +187,8 @@ export const SectionHero = () => {
 							)}
 						</div>
 
-						<div
-							ref={avatarRef}
-							className="relative flex-shrink-0 will-change-transform"
-							style={{ transition: 'transform 0.6s var(--ease-out)' }}
-							onMouseMove={handleMouseMove}
-							onMouseLeave={handleMouseLeave}
-						>
-							<div
-								ref={borderRef}
-								className="rounded-[8px] p-px shadow-card"
-								style={{ background: 'hsl(var(--border))', transition: 'background 0.2s ease' }}
-							>
-								<div className="relative w-[92px] h-[92px] rounded-[7px] overflow-hidden bg-background">
-									<img
-										className="w-full h-full object-cover block"
-										alt={data.name}
-										src="images/avatar.jpeg"
-										width={92}
-										height={92}
-										loading="eager"
-									/>
-									<div
-										ref={shineRef}
-										className="absolute pointer-events-none mix-blend-overlay opacity-0 will-change-transform"
-										style={{
-											inset: '-50%',
-											backgroundImage:
-												'linear-gradient(105deg, hsla(0,50%,72%,0.9) 0%, hsla(60,50%,72%,0.9) 17%, hsla(120,50%,72%,0.9) 33%, hsla(180,50%,72%,0.9) 50%, hsla(240,50%,72%,0.9) 67%, hsla(300,50%,72%,0.9) 83%, hsla(360,50%,72%,0.9) 100%)',
-											transition: 'opacity 0.4s ease, transform 0.12s ease'
-										}}
-									/>
-									<div
-										ref={highlightRef}
-										className="absolute top-0 left-0 w-[80px] h-[80px] rounded-full pointer-events-none mix-blend-screen opacity-0 will-change-transform"
-										style={{
-											background:
-												'radial-gradient(circle, rgba(255,255,255,0.2) 0%, transparent 65%)',
-											transition: 'opacity 0.25s ease, transform 0.08s ease'
-										}}
-									/>
-								</div>
-							</div>
-							<div
-								className="absolute bottom-[-6px] right-[-6px] w-[30px] h-[30px] rounded-full bg-background border border-border grid place-items-center text-[15px] animate-[hero-wave_3.4s_ease-in-out_infinite] origin-[70%_80%] motion-reduce:animate-none"
-								aria-hidden="true"
-							>
-								👋
-							</div>
-						</div>
+						<AvatarCard size={AVATAR_SIZE_DESKTOP} className="max-sm:hidden" />
 					</div>
-
-					{/* TODO: decide between hero widget vs navbar badge */}
 				</div>
 			</div>
 

--- a/src/components/pages/home/section-projects.tsx
+++ b/src/components/pages/home/section-projects.tsx
@@ -131,7 +131,7 @@ export const SectionProjects = ({ projects }: { projects: Project[] }) => {
 							}}
 							data-idx={i}
 							href={`/projects/${project.slug}`}
-							className="group relative grid grid-cols-[56px_1fr_auto_auto] items-center gap-[26px] px-[14px] py-[30px] border-b border-border last:border-b-0 text-inherit no-underline"
+							className="group relative grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[56px_1fr_auto_auto] items-center gap-[14px] sm:gap-[26px] py-[18px] sm:py-[30px] sm:px-[14px] border-b border-border last:border-b-0 text-inherit no-underline"
 							onMouseEnter={(e) => showPreview(i, e)}
 						>
 							<span className="font-mono text-[12px] text-muted-foreground group-hover:text-[var(--color-orange-primary)] transition-colors duration-300">

--- a/src/components/pages/home/section-work-experience.tsx
+++ b/src/components/pages/home/section-work-experience.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 
 import { Chip } from '@/components/ui/chip';
+import { EntryCard } from '@/components/ui/entry-card';
 import { Section } from '@/components/ui/section';
 import { SectionHeading } from '@/components/ui/section-heading';
 import { useLocale } from '@/contexts/locale-context';
@@ -17,19 +18,7 @@ export const SectionWorkExperience = () => {
 			/>
 			<div className="flex flex-col gap-[14px]">
 				{data.work.map(({ company, title, description, link, preview, stack, start, end }, i) => (
-					<div
-						key={company}
-						className="entry-card spotlight-border grid grid-cols-[48px_1fr_auto] gap-[18px] p-[22px_22px_22px_20px] border border-border rounded-xl shadow-card"
-						onMouseMove={(e) => {
-							const r = e.currentTarget.getBoundingClientRect();
-							e.currentTarget.style.setProperty('--mouse-x', `${e.clientX - r.left}px`);
-							e.currentTarget.style.setProperty('--mouse-y', `${e.clientY - r.top}px`);
-						}}
-						onMouseLeave={(e) => {
-							e.currentTarget.style.setProperty('--mouse-x', '-999px');
-							e.currentTarget.style.setProperty('--mouse-y', '-999px');
-						}}
-					>
+					<EntryCard key={company}>
 						<div className="w-11 h-11 rounded-[9px] border border-border bg-background grid place-items-center overflow-hidden shrink-0">
 							{preview && (
 								<img
@@ -66,12 +55,12 @@ export const SectionWorkExperience = () => {
 							{start} — {end}
 						</span>
 
-						<p className="m-0 mt-3 font-mono text-[12.5px] leading-[1.7] text-foreground/90 text-pretty [grid-column:2_/-1]">
+						<p className="m-0 mt-3 font-mono text-[12.5px] leading-[1.7] text-foreground/90 text-pretty [grid-column:1_/-1] sm:[grid-column:2_/-1]">
 							{(translations.data.work[i]?.description ?? description).trim()}
 						</p>
 
 						{stack.length > 0 && (
-							<div className="mt-[14px] flex flex-wrap gap-[5px] [grid-column:2_/-1]">
+							<div className="mt-[14px] flex flex-wrap gap-[5px] [grid-column:1_/-1] sm:[grid-column:2_/-1]">
 								{stack.map((st) => {
 									const { label, icon } = st as { label: string; icon: ReactElement };
 									return (
@@ -83,7 +72,7 @@ export const SectionWorkExperience = () => {
 								})}
 							</div>
 						)}
-					</div>
+					</EntryCard>
 				))}
 			</div>
 		</Section>

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,4 +1,5 @@
 import { MoonIcon, SunIcon } from '@radix-ui/react-icons';
+import type React from 'react';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -9,7 +10,12 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { applyTheme } from '@/utils/theme';
 
-export function ThemeToggle() {
+type ContentProps = React.ComponentPropsWithoutRef<typeof DropdownMenuContent>;
+
+export function ThemeToggle({
+	align = 'end',
+	side = 'bottom'
+}: Pick<ContentProps, 'align' | 'side'>) {
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -24,7 +30,7 @@ export function ThemeToggle() {
 					<span className="sr-only">Toggle theme</span>
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="end">
+			<DropdownMenuContent align={align} side={side}>
 				<DropdownMenuItem onClick={() => applyTheme('light')}>Light</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => applyTheme('dark')}>Dark</DropdownMenuItem>
 				<DropdownMenuItem onClick={() => applyTheme('system')}>System</DropdownMenuItem>

--- a/src/components/ui/entry-card.tsx
+++ b/src/components/ui/entry-card.tsx
@@ -11,12 +11,20 @@ export function EntryCard({ children, className }: EntryCardProps) {
 	return (
 		<div
 			className={cn(
-				'entry-card',
-				'relative grid grid-cols-[48px_1fr_auto] gap-[18px] p-[22px_22px_22px_20px]',
-				'border border-border rounded-[12px] overflow-hidden shadow-card',
-				'transition-[transform,border-color,box-shadow] duration-500 ease-out will-change-transform',
+				'entry-card spotlight-border',
+				'grid grid-cols-[48px_1fr_auto] gap-[14px] sm:gap-[18px] p-[14px] sm:p-[22px_22px_22px_20px]',
+				'border border-border rounded-xl shadow-card',
 				className
 			)}
+			onMouseMove={(e) => {
+				const r = e.currentTarget.getBoundingClientRect();
+				e.currentTarget.style.setProperty('--mouse-x', `${e.clientX - r.left}px`);
+				e.currentTarget.style.setProperty('--mouse-y', `${e.clientY - r.top}px`);
+			}}
+			onMouseLeave={(e) => {
+				e.currentTarget.style.setProperty('--mouse-x', '-999px');
+				e.currentTarget.style.setProperty('--mouse-y', '-999px');
+			}}
 		>
 			{children}
 		</div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -239,6 +239,13 @@
 	clip-path: circle(0% at calc(100% - 42px) 34px);
 }
 
+@utility now-playing-transition {
+	transition:
+		width 600ms cubic-bezier(0.22, 1, 0.36, 1),
+		height 600ms cubic-bezier(0.22, 1, 0.36, 1),
+		border-radius 900ms ease-out;
+}
+
 @utility overlay-grid {
 	background-size: 54px 54px;
 	background-image:


### PR DESCRIPTION
## What
- Move theme toggle into mobile hamburger menu next to socials
- Fix now-playing badge on mobile — cap width, expand anchor left, remove inline styles
- Fix card description alignment: full-width on mobile so text starts at logo's left edge
- Tighten selected work project row padding to align numbers with section heading

## Linear
Closes PER-60

## Checklist
- [x] `pnpm validate` passes
- [x] Tested locally